### PR TITLE
:memo: Document min PowerShell version

### DIFF
--- a/docs/getting-started/full-dotnet/existing-db.rst
+++ b/docs/getting-started/full-dotnet/existing-db.rst
@@ -19,6 +19,7 @@ The following prerequisites are needed to complete this walkthrough:
 
 * Visual Studio 2013 or Visual Studio 2015
 * `Latest version of NuGet Package Manager`_
+* `Latest version of Windows PowerShell <https://www.microsoft.com/en-us/download/details.aspx?id=40855>`_
 * `Blogging database`_
 
 Latest version of NuGet Package Manager

--- a/docs/getting-started/full-dotnet/new-db.rst
+++ b/docs/getting-started/full-dotnet/new-db.rst
@@ -19,6 +19,7 @@ The following prerequisites are needed to complete this walkthrough:
 
 * Visual Studio 2013 or Visual Studio 2015
 * `Latest version of NuGet Package Manager`_
+* `Latest version of Windows PowerShell <https://www.microsoft.com/en-us/download/details.aspx?id=40855>`_
 
 Latest version of NuGet Package Manager
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
For Package Manager Console commands you need PowerShell 3.0 or newer.
Adding this to the pre-req section. Doesn't apply to UWP since you need
Windows 10 for that anyway.
Resolves #101