### PR TITLE
Remove ASP.NET Core references

### DIFF
--- a/docs/platforms/aspnetcore/getting-started.rst
+++ b/docs/platforms/aspnetcore/getting-started.rst
@@ -1,9 +1,9 @@
-Getting Started on ASP.NET Core
-===============================
+Getting Started on ASP.NET 5
+============================
 
 These 101 tutorials require no previous knowledge of Entity Framework (EF) or Visual Studio. They will take you step-by-step through creating a simple application that queries and saves data from a database.
 
-Entity Framework can create a model based on an existing database, or create a database for you based on your model. The following tutorials will demonstrate both of these approaches using an ASP.NET Core application.
+Entity Framework can create a model based on an existing database, or create a database for you based on your model. The following tutorials will demonstrate both of these approaches using an ASP.NET 5 application.
 
 Available Tutorials
 -------------------

--- a/docs/platforms/aspnetcore/index.rst
+++ b/docs/platforms/aspnetcore/index.rst
@@ -1,10 +1,10 @@
-ASP.NET Core
-============
+ASP.NET 5
+=========
 
-These articles provide documentation for using EF with ASP.NET Core.
+These articles provide documentation for using EF with ASP.NET 5.
 
 .. toctree::
     :titlesonly:
-    :caption: The following articles are available
+    :caption: The following articles are available for ASP.NET 5
 
     getting-started


### PR DESCRIPTION
ASP.NET will be rebranded to ASP.NET Core... but the current release is
still ASP.NET 5 (so reverting the title/text changes).

Resolves #131