### PR TITLE
Fix build warnings

### DIFF
--- a/docs/miscellaneous/configuring-dbcontext.rst
+++ b/docs/miscellaneous/configuring-dbcontext.rst
@@ -51,7 +51,7 @@ Constructor argument
 This approach can be used with or without dependency injection.
 
 .. code-block:: csharp
-  :caption: Context code
+  :caption: Context code with constructor
 
   public class BloggingContext : DbContext
   {
@@ -102,7 +102,7 @@ OnConfiguring
   target the full database). See `Combinations`_.
 
 .. code-block:: csharp
-  :caption: Context code
+  :caption: Context code with OnConfiguring
 
   public class BloggingContext : DbContext
   {

--- a/docs/miscellaneous/index.rst
+++ b/docs/miscellaneous/index.rst
@@ -3,7 +3,7 @@ Miscellaneous
 
 .. toctree::
     :titlesonly:
-    :caption: The following articles are available
+    :caption: The following articles cover miscellaneous topics
 
     logging
     testing

--- a/docs/platforms/aspnetcore/existing-db.rst
+++ b/docs/platforms/aspnetcore/existing-db.rst
@@ -60,7 +60,6 @@ To enable reverse engineering from an existing database we need to install a cou
   * Locate the ``commands`` section and add the ``ef`` command as shown below
 
 .. literalinclude:: sample/src/EFGetStarted.AspNet5.ExistingDb/project.json
-        :language: json
         :linenos:
         :lines: 26-29
         :emphasize-lines: 3

--- a/docs/platforms/aspnetcore/new-db.rst
+++ b/docs/platforms/aspnetcore/new-db.rst
@@ -54,7 +54,6 @@ Later in this walkthrough we will also be using some Entity Framework commands t
 	* Locate the ``commands`` section and add the ``ef`` command as shown below
 
 .. literalinclude:: sample/src/EFGetStarted.AspNet5.NewDb/project.json
-        :language: json
         :linenos:
         :lines: 25-29
         :emphasize-lines: 3

--- a/docs/platforms/coreclr/index.rst
+++ b/docs/platforms/coreclr/index.rst
@@ -5,7 +5,7 @@ EF can be used on all platforms (Windows, OSX, Linux, etc.) that support .NET Co
 
 .. toctree::
   :titlesonly:
-  :caption: The following articles are available
+  :caption: The following .NET Core articles are available
 
   getting-started-linux
   getting-started-osx

--- a/docs/platforms/full-dotnet/index.rst
+++ b/docs/platforms/full-dotnet/index.rst
@@ -5,6 +5,6 @@ These articles provide documentation for using EF on the full .NET Framework (Co
 
 .. toctree::
     :titlesonly:
-    :caption: The following articles are available
+    :caption: The following Full .NET Framework articles are available
 
     getting-started

--- a/docs/platforms/uwp/index.rst
+++ b/docs/platforms/uwp/index.rst
@@ -5,7 +5,7 @@ These articles provide documentation for using EF on Universal Windows Platform.
 
 .. toctree::
     :titlesonly:
-    :caption: The following articles are available
+    :caption: The following UWP articles are available
 
     getting-started
     netnative

--- a/docs/platforms/uwp/sample/EFGetStarted.UWP/Model.cs
+++ b/docs/platforms/uwp/sample/EFGetStarted.UWP/Model.cs
@@ -10,7 +10,7 @@ namespace EFGetStarted.UWP
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
-            optionsBuilder.UseSqlite($"Filename=Blogging.db");
+            optionsBuilder.UseSqlite("Filename=Blogging.db");
         }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/docs/saving/sample/EFSaving/Basics/Sample.cs
+++ b/docs/saving/sample/EFSaving/Basics/Sample.cs
@@ -20,7 +20,7 @@ namespace EFSaving.Basics
                 db.Blogs.Add(blog);
                 db.SaveChanges();
 
-                Console.WriteLine($"{blog.BlogId}: {blog.Url}");
+                Console.WriteLine(blog.BlogId + ": " +  blog.Url);
             }
 
             using (var db = new BloggingContext())

--- a/docs/saving/sample/EFSaving/ExplicitValuesGenerateProperties/Sample.cs
+++ b/docs/saving/sample/EFSaving/ExplicitValuesGenerateProperties/Sample.cs
@@ -21,7 +21,7 @@ namespace EFSaving.ExplicitValuesGenerateProperties
 
                 foreach (var employee in db.Employees)
                 {
-                    Console.WriteLine($"{employee.EmployeeId}: {employee.Name}, {employee.EmploymentStarted}");
+                    Console.WriteLine(employee.EmployeeId + ": " + employee.Name + ", " + employee.EmploymentStarted);
                 }
             }
 
@@ -51,7 +51,7 @@ namespace EFSaving.ExplicitValuesGenerateProperties
 
                 foreach (var employee in db.Employees)
                 {
-                    Console.WriteLine($"{employee.EmployeeId}: {employee.Name}");
+                    Console.WriteLine(employee.EmployeeId + ": " + employee.Name);
                 }
             }
         }


### PR DESCRIPTION
Fixing various build warnings that had crept in.
C# syntax highlighter doesn't support string interpolation yet, so just
moving to concatenation for the moment.