### PR TITLE
vs restart when Scaffold-DbContest not recognized

### DIFF
--- a/docs/platforms/aspnetcore/existing-db.rst
+++ b/docs/platforms/aspnetcore/existing-db.rst
@@ -68,7 +68,7 @@ Reverse engineer your model
 Now it's time to create the EF model based on your existing database.
 
 * :menuselection:`Tools –> NuGet Package Manager –> Package Manager Console`
-* Run the following command to create a model from the existing database
+* Run the following command to create a model from the existing database, if the command is not recognized you may need to restart visual studio
 
 .. literalinclude:: _static/reverse-engineer-command.txt
 

--- a/docs/platforms/aspnetcore/existing-db.rst
+++ b/docs/platforms/aspnetcore/existing-db.rst
@@ -68,7 +68,7 @@ Reverse engineer your model
 Now it's time to create the EF model based on your existing database.
 
 * :menuselection:`Tools –> NuGet Package Manager –> Package Manager Console`
-* Run the following command to create a model from the existing database, if the command is not recognized you may need to restart visual studio
+* Run the following command to create a model from the existing database. If you receive an error stating the term 'Scaffold-DbContext' is not recognized as the name of a cmdlet, then close and reopen Visual Studio.
 
 .. literalinclude:: _static/reverse-engineer-command.txt
 


### PR DESCRIPTION
Restarting vs is usually needed in order to run Scaffold-DbContext
 -Discussed in more detail here: https://github.com/aspnet/EntityFramework/issues/5376