### PR TITLE
Sequence sample lines reference fix

### DIFF
--- a/docs/modeling/relational/sequences.rst
+++ b/docs/modeling/relational/sequences.rst
@@ -22,7 +22,7 @@ You can use the Fluent API to create a sequence in the model.
 
 .. includesamplefile:: Modeling/FluentAPI/Samples/Relational/Sequence.cs
         :language: c#
-        :lines: 5-13
+        :lines: 5-20
         :emphasize-lines: 7
         :linenos:
 

--- a/docs/modeling/relational/sequences.rst
+++ b/docs/modeling/relational/sequences.rst
@@ -22,7 +22,7 @@ You can use the Fluent API to create a sequence in the model.
 
 .. includesamplefile:: Modeling/FluentAPI/Samples/Relational/Sequence.cs
         :language: c#
-        :lines: 5-15
+        :lines: 5-13
         :emphasize-lines: 7
         :linenos:
 


### PR DESCRIPTION
The original included part of the Order class:
```
public class Order
```
Now it is gone. If the intention was to include the whole class then it should reference lines `5-20` instead.