### PR TITLE
Fix broken Microsoft.EntityFrameworkCore.InMemory package link

### DIFF
--- a/docs/providers/in-memory/index.rst
+++ b/docs/providers/in-memory/index.rst
@@ -10,7 +10,7 @@ This database provider allows Entity Framework Core to be used with an in-memory
 Install
 -------
 
-Install the `Microsoft.EntityFrameworkCore.InMemory NuGet package <hhttps://www.nuget.org/packages/Microsoft.EntityFrameworkCore.InMemory/>`_.
+Install the `Microsoft.EntityFrameworkCore.InMemory NuGet package <https://www.nuget.org/packages/Microsoft.EntityFrameworkCore.InMemory/>`_.
 
 .. code-block:: text
 


### PR DESCRIPTION
There was an extraneous "h" in the `Microsoft.EntityFrameworkCore.InMemory` NuGet package link, which caused it to not work.