### PR TITLE
Replace ASP.NET 5 references with ASP.NET Core

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Information on contributing to this repo is in the [Contributing Guide](https://
 
 The documentation is built using [Sphinx](http://sphinx-doc.org) and [reStructuredText](http://sphinx-doc.org/rest.html), and then hosted by [ReadTheDocs](http://aspnet.readthedocs.org).
 
-This project shares the same process as the ASP.NET 5 project for building and contributing documentation. Please review the following resources from the ASP.NET 5 project:
+This project shares the same process as the ASP.NET Core project for building and contributing documentation. Please review the following resources from the ASP.NET Core project:
 
 * [Building and contributing documentation](https://github.com/aspnet/Docs/blob/master/CONTRIBUTING.md)
 * [Style guide](http://docs.asp.net/en/latest/contribute/style-guide.html)


### PR DESCRIPTION
Replaced the two ASP.NET 5 references in `CONTRIBUTING.md` with ASP.NET Core.