### PR TITLE
Updating the documentation to include the base abstract class case in TPH

### DIFF
--- a/docs/modeling/relational/inheritance.rst
+++ b/docs/modeling/relational/inheritance.rst
@@ -40,7 +40,7 @@ You can use the Fluent API to configure the name and type of the discriminator c
         :emphasize-lines: 7-10
         :linenos:
 
-You can also use the Fluent API to configure a discriminator on a special value. This is useful when you're mapping to an existing database and there are hardcoded ``id``s for handling specific types. You can instead use a discriminator and a base abstract class and strong-type your code.
+You can also use the Fluent API to configure a discriminator on a special value. This is useful when you're mapping to an existing database and there are hardcoded ``ids`` for handling specific types. You can instead use a discriminator and a base abstract class and strong-type your code.
 
 .. includesamplefile:: Modeling/FluentAPI/Samples/InheritanceTPHAbstractDiscriminator.cs
         :language: c#

--- a/docs/modeling/relational/inheritance.rst
+++ b/docs/modeling/relational/inheritance.rst
@@ -39,3 +39,11 @@ You can use the Fluent API to configure the name and type of the discriminator c
         :lines: 5-27
         :emphasize-lines: 7-10
         :linenos:
+
+You can also use the Fluent API to configure a discriminator on a special value. This is useful when you're mapping to an existing database and there are hardcoded `id`s for handling specific types. You can instead use a discriminator and a base abstract class and strong-type your code.
+
+.. includesamplefile:: Modeling/FluentAPI/Samples/InheritanceTPHAbstractDiscriminator.cs
+        :language: c#
+        :lines: 5-27
+        :emphasize-lines: 7-9
+        :linenos:

--- a/docs/modeling/relational/inheritance.rst
+++ b/docs/modeling/relational/inheritance.rst
@@ -40,7 +40,7 @@ You can use the Fluent API to configure the name and type of the discriminator c
         :emphasize-lines: 7-10
         :linenos:
 
-You can also use the Fluent API to configure a discriminator on a special value. This is useful when you're mapping to an existing database and there are hardcoded `id`s for handling specific types. You can instead use a discriminator and a base abstract class and strong-type your code.
+You can also use the Fluent API to configure a discriminator on a special value. This is useful when you're mapping to an existing database and there are hardcoded ``id``s for handling specific types. You can instead use a discriminator and a base abstract class and strong-type your code.
 
 .. includesamplefile:: Modeling/FluentAPI/Samples/InheritanceTPHAbstractDiscriminator.cs
         :language: c#

--- a/docs/modeling/relational/inheritance.rst
+++ b/docs/modeling/relational/inheritance.rst
@@ -40,7 +40,7 @@ You can use the Fluent API to configure the name and type of the discriminator c
         :emphasize-lines: 7-10
         :linenos:
 
-You can also use the Fluent API to configure a discriminator on a special value. This is useful when you're mapping to an existing database and there are hardcoded ``ids`` for handling specific types. You can instead use a discriminator and a base abstract class and strong-type your code.
+You can also use the Fluent API to configure a discriminator on a special value. This very is useful when you're mapping to an existing database and there is a table with very few entries, and the ``ids`` are checked in the code for handling each specific value as a type. You can instead use a base abstract class and strong-type your code with one type per entity.
 
 .. includesamplefile:: Modeling/FluentAPI/Samples/InheritanceTPHAbstractDiscriminator.cs
         :language: c#

--- a/samples/Modeling/FluentAPI/Samples/InheritanceTPHAbstractDiscriminator.cs
+++ b/samples/Modeling/FluentAPI/Samples/InheritanceTPHAbstractDiscriminator.cs
@@ -1,0 +1,30 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace EFModeling.Configuring.FluentAPI.Samples.InheritanceTphAbstractDiscriminator
+{
+    class MyContext : DbContext
+    {
+        public DbSet<Blog> Blogs { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Blog>()
+                .HasDiscriminator(b => b.BlogId)
+                .HasValue<MySpecialBlog>(42);
+        }
+    }
+
+    public abstract class Blog
+    {
+        public int BlogId { get; set; }
+        public string Url { get; set; }
+    }
+
+    public class MyCustomBlog : Blog
+    {
+        public virtual string MyCustomMethod()
+        {
+            return "I'm a custom blog";
+        }
+    }
+}


### PR DESCRIPTION
Hi!

I'm not convinced with my writing, but please feel free to use this as a starting point for a better PR.

TL;DR: there was no mention of using an abstract class in TPH.

I'm mapping a model to an existing database, and I found a very useful scenario for discriminators. We have a `Products` table, a `Licenses` table and a `ProductLicenses` table. The `Licenses` table has only six entries, and each one represents a license type with a very specific business logic.

In the old code I'm rewriting, we checked the `Id` to find out the license type and then handle it. E.g.:

``` cs
product.ProductLicenses.Any(l => l.LicenseId == Guid.Parse("....")); // if we offer this specific license type do something
```

This seemed ugly, and with EFCore I found I can strong-type this and have a simpler code. I'm setting up a discriminator like this:

``` cs
modelBuilder.Entity<ProductLicense>(entity =>
{
    entity.HasDiscriminator(e => e.LicenseId)
        .HasValue<SomeProductLicense>(Guid.Parse("F26E3C37-4709-496E-81B0-3AFFD6776D01"));
});
```

Declaring `ProductLicense` abstract (this is important! otherwise it complains you haven't set up a discriminator for the base type).

``` cs
public abstract class ProductLicense
```

And then the check is not only strongly-typed but much simpler:

``` cs
product.SomeProductLicense != null // if we offer this specific license type
```

Let me know if I can help or clarify!
