### PR TITLE
Adding a related entity issue in  Sample.cs

### DIFF
--- a/samples/core/Saving/Saving/RelatedData/Sample.cs
+++ b/samples/core/Saving/Saving/RelatedData/Sample.cs
@@ -35,7 +35,7 @@ namespace EFSaving.RelatedData
             // Adding a related entity
             using (var context = new BloggingContext())
             {
-                var blog = context.Blogs.First();
+                var blog = context.Blogs.Include(b => b.Posts).First();
                 var post = new Post { Title = "Intro to EF Core" };
 
                 blog.Posts.Add(post);


### PR DESCRIPTION
Adding a related entity issue in  EntityFramework.Docs/samples/core/Saving/Saving/RelatedData/Sample.cs

Object reference not set to an instance of an object.

because blog.Posts is null, not loaded and no lazy loading works


so how to add related:

1) Include(b => b.Posts) required

2) or will be changed in the future ?


[core 1.1.0]