### PR TITLE
Fixed typo in configuring-dbcontext.md

### DIFF
--- a/entity-framework/core/miscellaneous/configuring-dbcontext.md
+++ b/entity-framework/core/miscellaneous/configuring-dbcontext.md
@@ -103,7 +103,7 @@ public void ConfigureServices(IServiceCollection services)
 }
 ````
 
-This requires adding a [constructor argument](#constructor-argument) to you DbContext type that accepts `DbContextOptions`.
+This requires adding a [constructor argument](#constructor-argument) to your DbContext type that accepts `DbContextOptions`.
 
 Context code
 


### PR DESCRIPTION
Fixed a typo on line 106.  Changed the word "you" to "your".