### PR TITLE
Update example to use dotnet add package

### DIFF
--- a/entity-framework/core/get-started/netcore/new-db-sqlite.md
+++ b/entity-framework/core/get-started/netcore/new-db-sqlite.md
@@ -40,7 +40,18 @@ dotnet new console
 
 To use EF Core, install the package for the database provider(s) you want to target. This walkthrough uses SQLite. For a list of available providers see [Database Providers](../../providers/index.md).
 
-*  Replace the `ConsoleApp.SQLite.csproj` contents with the following:
+* Install Microsoft.EntityFrameworkCore.Sqlite and Microsoft.EntityFrameworkCore.Design
+
+```
+dotnet add package Microsoft.EntityFrameworkCore.Sqlite
+dotnet add package Microsoft.EntityFrameworkCore.Design
+```
+
+*  Manually edit `ConsoleApp.SQLite.csproj` to add a DotNetCliToolReference to Microsoft.EntityFrameworkCore.Tools.DotNet
+
+ Note: A future version of `dotnet` will support DotNetCliToolReferences via `dotnet add tool`
+
+`ConsoleApp.SQLite.csproj` should now contain the following: 
 
 [!code[Main](../../../../samples/core/GetStarted/NetCore/ConsoleApp.SQLite/ConsoleApp.SQLite.csproj)]
 


### PR DESCRIPTION
In order to better educate audiences, all examples should use CLI tools where appropriate rather than suggesting "replace csproj with".  Where possible in this example, this change does just that.  Additionally, it makes note that a future change is coming to better handle `dotnet` CLI extensions.

This pull request reflects my thoughts described in https://github.com/NuGet/Home/issues/4901