### PR TITLE
DbContextFactoryOptions parameter was missing.

### DIFF
--- a/entity-framework/core/miscellaneous/configuring-dbcontext.md
+++ b/entity-framework/core/miscellaneous/configuring-dbcontext.md
@@ -157,7 +157,7 @@ namespace MyProject
 {
     public class BloggingContextFactory : IDbContextFactory<BloggingContext>
     {
-        public BloggingContext Create()
+        public BloggingContext Create(DbContextFactoryOptions options)
         {
             var optionsBuilder = new DbContextOptionsBuilder<BloggingContext>();
             optionsBuilder.UseSqlite("Data Source=blog.db");


### PR DESCRIPTION
The **Create** method of **IDbContextFactory<T>** require **DbContextFactoryOptions** as parameter. So I just added to the document.
Br,