### PR TITLE
2.0 preparation

### DIFF
--- a/entity-framework/core/get-started/general/efcore1.md
+++ b/entity-framework/core/get-started/general/efcore1.md
@@ -1,0 +1,67 @@
+---
+title: EF Core | Installing EF Core 1.x | Microsoft Docs
+author: divega
+ms.author: divega
+
+ms.date: 08/06/2017
+
+ms.assetid: e1bff2e3-6ea1-41e1-9ab1-d95ed2d86621
+ms.technology: entity-framework-core
+
+uid: core/get-started/general/efcore1
+---
+# Installing EF Core 1.x
+
+## Runtime
+
+You can install EF Core 1.x by installing a compatible version of an EF Core data provider from NuGet. E.g. you can install or upgrade the SQL Server provider in cross-platform .NET Core application executing this on the command line:
+
+``` console
+$ dotnet add package Microsoft.EntityFrameworkCore.SqlServer -v 1.1.2
+```
+
+For any type of application using Visual Studio’s Package Manager Console:
+
+``` console
+PM> install-package Microsoft.EntityFrameworkCore.SqlServer -Version 1.1.2
+```
+
+Or to upgrade to EF Core 1.1.2 from the Package Manager Console:
+
+``` console
+PM> update-package Microsoft.EntityFrameworkCore.SqlServer -Version 1.1.2
+```
+
+If you need to update an application that is using a third-party data provider, check for an update of the provider that is compatible with EF Core 1.x.
+
+## Tooling
+
+Install any pre-requisite updates to your development tools of choice, e.g. Visual Studio 2017, Visual Studio 2017 for Mac or Visual Studio Code, etc.
+
+To use the `dotnet ef` command line tools in cross-platoform development, your application’s `csproj` file should contain the following:
+
+``` xml
+<ItemGroup>
+  <DotNetCliToolReference
+      Include="Microsoft.EntityFrameworkCore.Tools.DotNet"
+      Version="1.0.1" />
+</ItemGroup>
+```
+
+The Package Manager Console EF Core commands for Visual Studio can be upgraded by issuing the following command:
+
+``` console
+PM> update-package Microsoft.EntityFrameworkCore.Tools -Version 1.1.2
+```
+
+Some design-time functionality such as `DbContext` scaffolding  requires installing the design-time package for the specific database provider. E.g. for the SQL Server provider you can use:  
+
+``` console
+$ dotnet add package Microsoft.EntityFrameworkCore.SqlServer.Design -v 1.1.2
+```
+
+Or from the Package Manager Console:
+
+``` console
+PM> install-package Microsoft.EntityFrameworkCore.SqlServer.Design -Version 1.1.2
+```

--- a/entity-framework/core/get-started/general/efcore2.md
+++ b/entity-framework/core/get-started/general/efcore2.md
@@ -1,0 +1,63 @@
+---
+title: EF Core | Installing EF Core 2.0 | Microsoft Docs
+author: divega
+ms.author: divega
+
+ms.date: 08/06/2017
+
+ms.assetid: 608cc774-c570-4809-8a3e-cd2c8446b8b2
+ms.technology: entity-framework-core
+
+uid: core/get-started/general/efcore2
+---
+# Installing EF Core 2.0
+
+## Runtime
+
+You can install EF Core 2.0 by installing a compatible version of an EF Core data provider from NuGet. E.g. you can install or upgrade the SQL Server provider in cross-platform .NET Core application executing this on the command line:
+
+``` console
+$ dotnet add package Microsoft.EntityFrameworkCore.SqlServer -v 2.0.0
+```
+
+For any type of application using Visual Studio’s Package Manager Console:
+
+``` console
+PM> install-package Microsoft.EntityFrameworkCore.SqlServer -Version 2.0.0
+```
+
+Or to upgrade to EF Core 2.0 from the Package Manager Console:
+
+``` console
+PM> update-package Microsoft.EntityFrameworkCore.SqlServer -Version 2.0.0
+```
+
+If you need to update an application that is using a third-party data provider, check for an update of the provider that is compatible with EF Core 2.0. Data providers for previous versions are not compatible with version 2.0.
+
+Applications targeting ASP.NET Core 2.0 can use EF Core 2.0 without additional dependencies besides third party data providers (applications targeting previous versions of ASP.NET Core will need to upgrade to ASP.NET Core 2.0).
+
+## Tooling
+
+If the application targets [.NET Core 2.0](https://www.microsoft.com/net/download/core), install any pre-requisite updates to your development tools of choice, e.g. Visual Studio 2017 15.3, Visual Studio 2017 for Mac or Visual Studio Code, etc.
+
+To use the `dotnet ef` command line tools in cross-platoform development, your application’s `csproj` file should contain the following:
+
+``` xml
+<ItemGroup>
+  <DotNetCliToolReference
+      Include="Microsoft.EntityFrameworkCore.Tools.DotNet"
+      Version="2.0.0" />
+</ItemGroup>
+```
+
+The Package Manager Console EF Core commands for Visual Studio can be upgraded by issuing the following command:
+
+``` console
+PM> update-package Microsoft.EntityFrameworkCore.Tools -Version 2.0.0
+```
+
+If your existing project references any of the tooling and design packages, make sure you update the version to 2.0.
+
+## Deprecated packages
+
+Some references to older EF Core packages may need to be removed manually. In particular, data provider design-time packages such as `Microsoft.EntityFrameworkCore.SqlServer.Design` or similar, are no longer required or supported in EF Core 2.0, but will not be automatically removed when upgrading other packages.

--- a/entity-framework/core/get-started/general/index.md
+++ b/entity-framework/core/get-started/general/index.md
@@ -1,0 +1,15 @@
+---
+title: EF Core | General Installation Instructions | Microsoft Docs
+author: divega
+ms.author: divega
+
+ms.date: 08/06/2017
+
+ms.assetid: df2e1f4d-ac80-4f09-a779-1d21a77569b4
+ms.technology: entity-framework-core
+
+uid: core/get-started/general/index
+---
+# General Installation Instructions
+
+Select the version of EF Core you want to install for detailed instructions. 

--- a/entity-framework/core/get-started/index.md
+++ b/entity-framework/core/get-started/index.md
@@ -1,5 +1,5 @@
 ---
-title: Getting Started | Microsoft Docs
+title: EF Core | Getting Started | Microsoft Docs
 author: rowanmiller
 ms.author: divega
 
@@ -7,13 +7,14 @@ ms.date: 10/27/2016
 
 ms.assetid: 3c88427c-20c6-42ec-a736-22d3eccd5071
 ms.technology: entity-framework-core
- 
+
 uid: core/get-started/index
 ---
 # Getting Started
 
-> [!NOTE]
-> This documentation is for EF Core. For EF6.x, see [Entity Framework 6](../../ef6/index.md).
+For a summary of the steps necessary to add EF Core to your application in different platforms and IDEs, see [General Installation Instructions](general/index.md).
+
+## Step-by-step Turorials
 
 These 101 tutorials require no previous knowledge of Entity Framework (EF) or a particular IDE. They will take you step-by-step through creating a simple application that queries and saves data from a database. We have provided tutorials to get you started on various operating systems and application types.
 

--- a/entity-framework/core/platforms/index.md
+++ b/entity-framework/core/platforms/index.md
@@ -1,5 +1,5 @@
 ---
-title: Platforms | Microsoft Docs
+title: EF Core | Platform Support | Microsoft Docs
 author: rowanmiller
 ms.author: divega
 ms.date: 03/13/2017
@@ -8,17 +8,19 @@ ms.technology: entity-framework-core
 uid: core/platforms/index
 ---
 
-# Platforms
-
-> [!NOTE]
-> This documentation is for EF Core. For EF6.x, see [Entity Framework 6](../../ef6/index.md).
+# Platform Support
 
 We want EF Core to be available anywhere you write .NET code, and we're still working towards that goal. The following table provides guidance for each platform where we want to enable EF Core.
 
+EF Core 2.0 targets and therefore requires .NET platforms that support [.NET Standard 2.0](https://docs.microsoft.com/en-us/dotnet/standard/net-standard).
 
-|Platform|Status
+| Platform | Status | 1.x requires | 2.x requires
 |-|-
-| **.NET Core** (ASP.NET Core, Console, etc.) | **Fully supported and recommended:** Covered by automated testing and many applications known to be using it successfully.
-| **.NET Framework** (WinForms, WPF, ASP.NET, Console, etc.) | **Fully supported and recommended:**  Covered by automated testing and many applications known to be using it successfully. EF 6 also available (see [Compare EF Core & EF6.x](../../efcore-and-ef6/index.md) to choose the right technology).
-| **Mono & Xamarin** | **In progress – issues may be encountered:** Dependent on recently added support for .NET Standard. Ad-hoc testing has been performed by the EF Core team and customers. Early adopters have reported some success but [issues have been encountered](https://github.com/aspnet/entityframework/issues?q=is%3Aopen+is%3Aissue+label%3Aarea-xamarin) and and others will likely be uncovered as testing continues.
-| **UWP** |  **In progress – issues may be encountered:** Ad-hoc testing has been performed by the EF Core team and customers. [Significant issues](https://github.com/aspnet/entityframework/issues?utf8=%E2%9C%93&q=is%3Aopen%20is%3Aissue%20label%3Aarea-uwp%20) reported when compiled with .NET Native toolchain, which is typically used during a release build, and is a requirement for deploying to the Windows Store. If you are not using .NET Native, or just want to experiment, these issues don't apply to you.
+| **.NET Core** (ASP.NET Core, Console, etc.) | **Fully supported and recommended:** Covered by automated testing and many applications known to be using it successfully. | Same version [.NET Core SDK](https://www.microsoft.com/net/core/) | Same version [.NET Core SDK](https://www.microsoft.com/net/core/)
+| **.NET Framework** (WinForms, WPF, ASP.NET, Console, etc.) | **Fully supported and recommended:**  Covered by automated testing and many applications known to be using it successfully. EF 6 also available in this platform (see [Compare EF Core & EF6.x](../../efcore-and-ef6/index.md) to choose the right technology). | .NET Framework 4.5.1 | .NET Framework 4.6.1
+| **Mono & Xamarin** | **In progress – issues may be encountered:** Ad-hoc testing has been performed by the EF Core team and customers. Early adopters have reported some success but [issues have been encountered](https://github.com/aspnet/entityframework/issues?q=is%3Aopen+is%3Aissue+label%3Aarea-xamarin) and others will likely be uncovered as testing continues. | Mono 4.6 | Mono 5.0
+| **Universal Windows Platform** |  **In progress – issues may be encountered:** Ad-hoc testing has been performed by the EF Core team and customers. [Significant issues](https://github.com/aspnet/entityframework/issues?utf8=%E2%9C%93&q=is%3Aopen%20is%3Aissue%20label%3Aarea-uwp%20) reported when compiled with .NET Native toolchain, which is typically used during a release build, and is a requirement for deploying to the Windows Store (if you are not using .NET Native, or just want to experiment, many of the issues will not affect you). | UWP 5.3.1 | UWP 6.0 <sup>(1)</sup>
+
+<sup>(1)</sup> Upcoming UWP 6.0 adds support for .NET Standard 2.0. We have started testing EF Core 2.0 with it and we will have more information to share about running on this platform soon.
+
+For any combination that doesn’t work as expected, we encourage creating new issues in the [EF Core issue tracker](https://github.com/aspnet/entityframework/issues/new), and for Xamarin related issues, the [Xamarin issue tracker](https://bugzilla.xamarin.com/newbug).

--- a/entity-framework/toc.md
+++ b/entity-framework/toc.md
@@ -1,10 +1,9 @@
 #[Entity Framework](index.md)
 
-##[Compare EF Core & EF6.x](efcore-and-ef6/index.md)
+##[Compare EF Core & EF6](efcore-and-ef6/index.md)
 ###[Which One Is Right for You](efcore-and-ef6/choosing.md)
 ###[Feature Comparison](efcore-and-ef6/features.md)
-###[EF6.x and EF Core in the Same Application](efcore-and-ef6/side-by-side.md)
-###[Porting from EF6.x to EF Core](efcore-and-ef6/porting/index.md)
+###[EF6 and EF Core in the Same Application](efcore-and-ef6/side-by-side.md)
 ####[Validate Requirements](efcore-and-ef6/porting/ensure-requirements.md)
 ####[Porting an EDMX-Based Model](efcore-and-ef6/porting/port-edmx.md)
 ####[Porting a Code-Based Model](efcore-and-ef6/porting/port-code.md)
@@ -12,6 +11,9 @@
 ##[Entity Framework Core](core/index.md)
 <!-- Getting Started -->
 ###[Getting Started](core/get-started/index.md)
+####[General Installation Instructions](core/get-started/general/index.md)
+#####[Installing EF Core 1.x](core/get-started/general/efcore1.md)
+#####[Installing EF Core 2.0](core/get-started/general/efcore2.md)
 ####[.NET Framework (Console, WinForms, WPF, etc.)](core/get-started/full-dotnet/index.md)
 #####[.NET Framework - New Database](core/get-started/full-dotnet/new-db.md)
 #####[.NET Framework - Existing Database](core/get-started/full-dotnet/existing-db.md)
@@ -71,7 +73,7 @@
 ####[🔧 Disconnected Entities](core/saving/disconnected-entities.md)
 ####[Explicit values for generated properties](core/saving/explicit-values-generated-properties.md)
 <!-- Platforms -->
-###[Platforms](core/platforms/index.md)
+###[Platform Support](core/platforms/index.md)
 <!-- Providers -->
 ###[Database Providers](core/providers/index.md)
 ####[Microsoft SQL Server](core/providers/sql-server/index.md)

--- a/entity-framework/toc.md
+++ b/entity-framework/toc.md
@@ -4,6 +4,7 @@
 ###[Which One Is Right for You](efcore-and-ef6/choosing.md)
 ###[Feature Comparison](efcore-and-ef6/features.md)
 ###[EF6 and EF Core in the Same Application](efcore-and-ef6/side-by-side.md)
+###[Porting from EF6 to EF Core](efcore-and-ef6/porting/index.md)
 ####[Validate Requirements](efcore-and-ef6/porting/ensure-requirements.md)
 ####[Porting an EDMX-Based Model](efcore-and-ef6/porting/port-edmx.md)
 ####[Porting a Code-Based Model](efcore-and-ef6/porting/port-code.md)


### PR DESCRIPTION
For preview it was ok to have ad-hoc instructions inline in blog posts as well as listing platforms that e.g. supported .NET Standard 2.0. With RTM we should be moving the useful parts of these into permanent documentation.