### PR TITLE
Self-close package reference nodes in .csproj xml

### DIFF
--- a/entity-framework/core/miscellaneous/1x-2x-upgrade.md
+++ b/entity-framework/core/miscellaneous/1x-2x-upgrade.md
@@ -166,10 +166,10 @@ To enable `Scaffold-DbContext` or `dotnet ef dbcontext scaffold` in EF Core 2.0,
 
 ``` xml
 <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer"
-    Version="2.0.0" >
+    Version="2.0.0" />
 <PackageReference Include="Microsoft.EntityFrameworkCore.Tools"
     Version="2.0.0"
-    PrivateAssets="All" >
+    PrivateAssets="All" />
 <DotNetCliToolReference Include="Microsoft.EntityFrameworkCore.Tools.DotNet"
-    Version="2.0.0" >
+    Version="2.0.0" />
 ```


### PR DESCRIPTION
At the bottom of [this docs page](https://docs.microsoft.com/en-us/ef/core/miscellaneous/1x-2x-upgrade) the XML nodes are not properly closed, which causes errors when you copy-paste the content to your .csproj file. This PR closes those nodes.