### PR TITLE
Add a missing "to"

### DIFF
--- a/entity-framework/core/modeling/indexes.md
+++ b/entity-framework/core/modeling/indexes.md
@@ -24,7 +24,7 @@ Indexes can not be created using data annotations.
 
 ## Fluent API
 
-You can use the Fluent API specify an index on a single property. By default, indexes are non-unique.
+You can use the Fluent API to specify an index on a single property. By default, indexes are non-unique.
 
 <!-- [!code-csharp[Main](samples/core/Modeling/FluentAPI/Samples/Index.cs?highlight=7,8)] -->
 ``` csharp


### PR DESCRIPTION
A side note: The [link in the site](https://docs.microsoft.com/en-us/ef/core/modeling/indexes) uses the `live` branch but the [contrib.](https://github.com/aspnet/EntityFramework.Docs/blob/live/CONTRIBUTING.md) page says it should be against `master` so I think one of these should change!