### PR TITLE
Change in IDesignTimeDbContextFactory

### DIFF
--- a/entity-framework/core/miscellaneous/configuring-dbcontext.md
+++ b/entity-framework/core/miscellaneous/configuring-dbcontext.md
@@ -145,7 +145,7 @@ namespace MyProject
 {
     public class BloggingContextFactory : IDesignTimeDbContextFactory<BloggingContext>
     {
-        public BloggingContext Create(string[] args)
+        public BloggingContext CreateDbContext(string[] args)
         {
             var optionsBuilder = new DbContextOptionsBuilder<BloggingContext>();
             optionsBuilder.UseSqlite("Data Source=blog.db");


### PR DESCRIPTION
Since `IDesignTimeDbContextFactory` got changed and `Create` got renamed to `CreateDbContext` this PR fixes the difference in the docs.