### PR TITLE
Add tip for importing specific tables

### DIFF
--- a/entity-framework/core/get-started/aspnetcore/existing-db.md
+++ b/entity-framework/core/get-started/aspnetcore/existing-db.md
@@ -85,6 +85,9 @@ Now it's time to create the EF model based on your existing database.
 ``` console
 Scaffold-DbContext "Server=(localdb)\mssqllocaldb;Database=Blogging;Trusted_Connection=True;" Microsoft.EntityFrameworkCore.SqlServer -OutputDir Models
 ```
+> [!TIP]  
+> You can specify which tables you want to generate models for by adding the `-Tables Blog,Post` argument to the command above.
+
 
 The reverse engineer process created entity classes (`Blog.cs` & `Post.cs`) and a derived context (`BloggingContext.cs`) based on the schema of the existing database.
 


### PR DESCRIPTION
Since some people are developing new applications only needing a subset of the tables that exists in a given database I think it's important to add this to the official documentation even though it's been covered in an [issue](https://github.com/aspnet/EntityFrameworkCore/issues/7930) here on Github and [StackOverflow](https://stackoverflow.com/questions/39065769/can-we-scaffold-dbcontext-from-selected-tables-of-an-existing-database).