### PR TITLE
fix titles

### DIFF
--- a/entity-framework/core/extensions/autohistory.md
+++ b/entity-framework/core/extensions/autohistory.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Tools & Extensions - Microsoft.EntityFrameworkCore.AutoHistory | Microsoft Docs
+title: Microsoft.EntityFrameworkCore.AutoHistory - Tools & Extensions - EF Core
 author: ErikEJ
 ms.author: divega
 ms.date: 02/28/2017

--- a/entity-framework/core/extensions/devart-entity-developer.md
+++ b/entity-framework/core/extensions/devart-entity-developer.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Tools & Extensions - Devart Entity Developer | Microsoft Docs
+title: Devart Entity Developer - Tools & Extensions - EF Core
 author: ErikEJ
 ms.author: divega
 ms.date: 02/28/2017

--- a/entity-framework/core/extensions/dynamiclinq.md
+++ b/entity-framework/core/extensions/dynamiclinq.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Tools & Extensions - Microsoft.EntityFrameworkCore.DynamicLinq | Microsoft Docs
+title: Microsoft.EntityFrameworkCore.DynamicLinq - Tools & Extensions - EF Core
 author: ErikEJ
 ms.author: divega
 ms.date: 02/28/2017

--- a/entity-framework/core/extensions/efcore-practices.md
+++ b/entity-framework/core/extensions/efcore-practices.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Tools & Extensions - EFCore.Practices | Microsoft Docs
+title: EFCore.Practices - Tools & Extensions - EF Core
 author: ErikEJ
 ms.author: divega
 ms.date: 01/19/2017

--- a/entity-framework/core/extensions/efsecondlevelcache-core.md
+++ b/entity-framework/core/extensions/efsecondlevelcache-core.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Tools & Extensions - EFSecondLevelCache.Core | Microsoft Docs
+title: EFSecondLevelCache.Core - Tools & Extensions - EF Core
 author: ErikEJ
 ms.author: divega
 ms.date: 01/19/2017

--- a/entity-framework/core/extensions/entityframeworkcore-detached.md
+++ b/entity-framework/core/extensions/entityframeworkcore-detached.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Tools & Extensions - Detached.EntityFramework | Microsoft Docs
+title: Detached.EntityFramework - Tools & Extensions - EF Core
 author: ErikEJ
 ms.author: divega
 ms.date: 01/19/2017

--- a/entity-framework/core/extensions/entityframeworkcore-primarykey.md
+++ b/entity-framework/core/extensions/entityframeworkcore-primarykey.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Tools & Extensions - EntityFrameworkCore.PrimaryKey | Microsoft Docs
+title: EntityFrameworkCore.PrimaryKey - Tools & Extensions - EF Core
 author: ErikEJ
 ms.author: divega
 ms.date: 01/19/2017

--- a/entity-framework/core/extensions/entityframeworkcore-rx.md
+++ b/entity-framework/core/extensions/entityframeworkcore-rx.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Tools & Extensions - EntityFrameworkCore.Rx | Microsoft Docs
+title: EntityFrameworkCore.Rx - Tools & Extensions - EF Core
 author: ErikEJ
 ms.author: divega
 ms.date: 01/19/2017

--- a/entity-framework/core/extensions/entityframeworkcore-triggers.md
+++ b/entity-framework/core/extensions/entityframeworkcore-triggers.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Tools & Extensions - EntityFrameworkCore.Triggers | Microsoft Docs
+title: EntityFrameworkCore.Triggers - Tools & Extensions - EF Core
 author: ErikEJ
 ms.author: divega
 ms.date: 01/19/2017

--- a/entity-framework/core/extensions/entityframeworkcore-typedoriginalvalues.md
+++ b/entity-framework/core/extensions/entityframeworkcore-typedoriginalvalues.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Tools & Extensions - EntityFrameworkCore.TypedOriginalValues | Microsoft Docs
+title: EntityFrameworkCore.TypedOriginalValues - Tools & Extensions - EF Core
 author: ErikEJ
 ms.author: divega
 ms.date: 01/19/2017

--- a/entity-framework/core/extensions/index.md
+++ b/entity-framework/core/extensions/index.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Tools & Extensions | Microsoft Docs
+title: Tools & Extensions - EF Core
 author: rowanmiller
 ms.author: divega
 ms.date: 10/27/2016

--- a/entity-framework/core/extensions/linqkit.md
+++ b/entity-framework/core/extensions/linqkit.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Tools & Extensions - LinqKit.Microsoft.EntityFrameworkCore | Microsoft Docs
+title: LinqKit.Microsoft.EntityFrameworkCore - Tools & Extensions - EF Core
 author: ErikEJ
 ms.author: divega
 ms.date: 02/28/2017

--- a/entity-framework/core/extensions/llbl-gen-pro.md
+++ b/entity-framework/core/extensions/llbl-gen-pro.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Tools & Extensions - LLBLGen Pro | Microsoft Docs
+title: LLBLGen Pro - Tools & Extensions - EF Core
 author: rowanmiller
 ms.author: divega
 ms.date: 10/27/2016

--- a/entity-framework/core/extensions/unitofwork.md
+++ b/entity-framework/core/extensions/unitofwork.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Tools & Extensions - Microsoft.EntityFrameworkCore.UnitOfWork | Microsoft Docs
+title: Microsoft.EntityFrameworkCore.UnitOfWork - Tools & Extensions - EF Core
 author: ErikEJ
 ms.author: divega
 ms.date: 02/28/2017

--- a/entity-framework/core/get-started/aspnetcore/existing-db.md
+++ b/entity-framework/core/get-started/aspnetcore/existing-db.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Getting Started on ASP.NET Core - Existing Database | Microsoft Docs
+title: Getting Started on ASP.NET Core - Existing Database - EF Core
 author: rowanmiller
 ms.author: divega
 ms.date: 10/27/2016

--- a/entity-framework/core/get-started/aspnetcore/index.md
+++ b/entity-framework/core/get-started/aspnetcore/index.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Getting Started on ASP.NET Core | Microsoft Docs
+title: Getting Started on ASP.NET Core - EF Core
 author: rowanmiller
 ms.author: divega
 

--- a/entity-framework/core/get-started/aspnetcore/new-db.md
+++ b/entity-framework/core/get-started/aspnetcore/new-db.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Getting Started on ASP.NET Core - New database | Microsoft Docs
+title: Getting Started on ASP.NET Core - New database - EF Core
 author: rick-anderson
 ms.author: riande
 ms.author2: tdykstra

--- a/entity-framework/core/get-started/full-dotnet/existing-db.md
+++ b/entity-framework/core/get-started/full-dotnet/existing-db.md
@@ -1,5 +1,5 @@
 ﻿---
-title: EF Core | Getting Started on .NET Framework - Existing Database | Microsoft Docs
+title: Getting Started on .NET Framework - Existing Database - EF Core
 author: rowanmiller
 ms.author: divega
 

--- a/entity-framework/core/get-started/full-dotnet/index.md
+++ b/entity-framework/core/get-started/full-dotnet/index.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Getting Started on .NET Framework | Microsoft Docs
+title: Getting Started on .NET Framework - EF Core
 author: rowanmiller
 ms.author: divega
 

--- a/entity-framework/core/get-started/full-dotnet/new-db.md
+++ b/entity-framework/core/get-started/full-dotnet/new-db.md
@@ -1,5 +1,5 @@
 ﻿---
-title: EF Core | Getting Started on .NET Framework - New Database | Microsoft Docs
+title: Getting Started on .NET Framework - New Database - EF Core
 author: rowanmiller
 ms.author: divega
 

--- a/entity-framework/core/get-started/index.md
+++ b/entity-framework/core/get-started/index.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Getting Started | Microsoft Docs
+title: Getting Started - EF Core
 author: rowanmiller
 ms.author: divega
 

--- a/entity-framework/core/get-started/install/index.md
+++ b/entity-framework/core/get-started/install/index.md
@@ -1,5 +1,5 @@
 ---
-title: Installing EF Core | Microsoft Docs
+title: Installing EF Core 
 author: divega
 ms.author: divega
 

--- a/entity-framework/core/get-started/netcore/index.md
+++ b/entity-framework/core/get-started/netcore/index.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Getting Started on .NET Core | Microsoft Docs
+title: Getting Started on .NET Core - EF Core
 author: rowanmiller
 ms.author: divega
 

--- a/entity-framework/core/get-started/netcore/new-db-sqlite.md
+++ b/entity-framework/core/get-started/netcore/new-db-sqlite.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Getting Started on .NET Core - New database | Microsoft Docs
+title: Getting Started on .NET Core - New database - EF Core
 author: rick-anderson
 ms.author: riande
 ms.author2: tdykstra

--- a/entity-framework/core/get-started/uwp/getting-started.md
+++ b/entity-framework/core/get-started/uwp/getting-started.md
@@ -1,5 +1,5 @@
 ﻿---
-title: EF Core | Getting Started on UWP - New Database | Microsoft Docs
+title: Getting Started on UWP - New Database - EF Core
 author: rowanmiller
 ms.author: divega
 

--- a/entity-framework/core/get-started/uwp/index.md
+++ b/entity-framework/core/get-started/uwp/index.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Getting Started on UWP | Microsoft Docs
+title: Getting Started on UWP - EF Core
 author: rowanmiller
 ms.author: divega
 

--- a/entity-framework/core/index.md
+++ b/entity-framework/core/index.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Quick Overview | Microsoft Docs
+title: Quick Overview - EF Core
 author: rowanmiller
 ms.author: divega
 

--- a/entity-framework/core/miscellaneous/1x-2x-upgrade.md
+++ b/entity-framework/core/miscellaneous/1x-2x-upgrade.md
@@ -30,7 +30,7 @@ Updating an existing application to EF Core 2.0 may require:
 1. See in particular the [new pattern for initializing the application's service provider](#new-way-of-getting-application-services) described below.
 
 > [!TIP]  
-> The adoption of this new pattern when updating applications to 2.0 is highly recommended and is required in order for product features like Entity Framework Core Migrations to work. The other common alternative is to [implement *IDesignTimeDbContextFactory\<TContext>*](configuring-dbcontext.md#use-idesigntimedbcontextfactory).
+> The adoption of this new pattern when updating applications to 2.0 is highly recommended and is required in order for product features like Entity Framework Core Migrations to work. The other common alternative is to [implement *IDesignTimeDbContextFactory\<TContext>*](configuring-dbcontext.md#using-idesigntimedbcontextfactorytcontext).
 
 2. Applications targeting ASP.NET Core 2.0 can use EF Core 2.0 without additional dependencies besides third party database providers. However, applications targeting previous versions of ASP.NET Core need to upgrade to ASP.NET Core 2.0 in order to use EF Core 2.0. For more details on upgrading ASP.NET Core applications to 2.0 see [the ASP.NET Core documentation on the subject](https://docs.microsoft.com/en-us/aspnet/core/migration/1x-to-2x/).
 

--- a/entity-framework/core/miscellaneous/1x-2x-upgrade.md
+++ b/entity-framework/core/miscellaneous/1x-2x-upgrade.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Upgrading from previous versions to EF Core 2 | Microsoft Docs
+title: Upgrading from previous versions to EF Core 2 - EF Core
 author: divega
 ms.author: divega
 

--- a/entity-framework/core/miscellaneous/1x-2x-upgrade.md
+++ b/entity-framework/core/miscellaneous/1x-2x-upgrade.md
@@ -30,7 +30,7 @@ Updating an existing application to EF Core 2.0 may require:
 1. See in particular the [new pattern for initializing the application's service provider](#new-way-of-getting-application-services) described below.
 
 > [!TIP]  
-> The adoption of this new pattern when updating applications to 2.0 is highly recommended and is required in order for product features like Entity Framework Core Migrations to work. The other common alternative is to [implement  *IDesignTimeDbContextFactory<TContext>*](configuring-dbcontext.md#use-idesigntimedbcontextfactory).
+> The adoption of this new pattern when updating applications to 2.0 is highly recommended and is required in order for product features like Entity Framework Core Migrations to work. The other common alternative is to [implement *IDesignTimeDbContextFactory\<TContext>*](configuring-dbcontext.md#use-idesigntimedbcontextfactory).
 
 2. Applications targeting ASP.NET Core 2.0 can use EF Core 2.0 without additional dependencies besides third party database providers. However, applications targeting previous versions of ASP.NET Core need to upgrade to ASP.NET Core 2.0 in order to use EF Core 2.0. For more details on upgrading ASP.NET Core applications to 2.0 see [the ASP.NET Core documentation on the subject](https://docs.microsoft.com/en-us/aspnet/core/migration/1x-to-2x/).
 

--- a/entity-framework/core/miscellaneous/cli/dotnet.md
+++ b/entity-framework/core/miscellaneous/cli/dotnet.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | .NET Core CLI | Microsoft Docs
+title: .NET Core CLI - EF Core
 author: rowanmiller
 ms.author: divega
 

--- a/entity-framework/core/miscellaneous/cli/index.md
+++ b/entity-framework/core/miscellaneous/cli/index.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Command Line Reference | Microsoft Docs
+title: Command-Line Reference - EF Core
 author: rowanmiller
 ms.author: divega
 
@@ -10,7 +10,7 @@ ms.technology: entity-framework-core
 
 uid: core/miscellaneous/cli/index
 ---
-# Command Line Reference
+# Command-Line Reference
 
 Entity Framework provides command line tooling to automate common tasks such as code generation and database migrations. There are two primary command line experiences that EF Core provides.
 * [Package Manager Console](powershell.md) Tools provide command line tools integrated into Visual Studio.

--- a/entity-framework/core/miscellaneous/cli/powershell.md
+++ b/entity-framework/core/miscellaneous/cli/powershell.md
@@ -1,5 +1,5 @@
 ﻿---
-title: EF Core | Package Manager Console (Visual Studio) | Microsoft Docs
+title: Package Manager Console (Visual Studio) - EF Core
 author: rowanmiller
 ms.author: divega
 

--- a/entity-framework/core/miscellaneous/configuring-dbcontext.md
+++ b/entity-framework/core/miscellaneous/configuring-dbcontext.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Configuring a DbContext | Microsoft Docs
+title: Configuring a DbContext - EF Core
 author: rowanmiller
 ms.author: divega
 

--- a/entity-framework/core/miscellaneous/connection-resiliency.md
+++ b/entity-framework/core/miscellaneous/connection-resiliency.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Connection Resiliency | Microsoft Docs
+title: Connection Resiliency - EF Core
 author: rowanmiller
 ms.author: divega
 ms.date: 11/15/2016

--- a/entity-framework/core/miscellaneous/connection-strings.md
+++ b/entity-framework/core/miscellaneous/connection-strings.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Connection Strings | Microsoft Docs
+title: Connection Strings - EF Core
 author: rowanmiller
 ms.author: divega
 

--- a/entity-framework/core/miscellaneous/logging.md
+++ b/entity-framework/core/miscellaneous/logging.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Logging | Microsoft Docs
+title: Logging - EF Core
 author: rowanmiller
 ms.author: divega
 

--- a/entity-framework/core/miscellaneous/rc1-rc2-upgrade.md
+++ b/entity-framework/core/miscellaneous/rc1-rc2-upgrade.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Upgrading from EF Core 1.0 RC1 to RC2 | Microsoft Docs
+title: Upgrading from EF Core 1.0 RC1 to RC2 - EF Core
 author: rowanmiller
 ms.author: divega
 

--- a/entity-framework/core/miscellaneous/rc2-rtm-upgrade.md
+++ b/entity-framework/core/miscellaneous/rc2-rtm-upgrade.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Upgrading from EF Core 1.0 RC2 to RTM | Microsoft Docs
+title: Upgrading from EF Core 1.0 RC2 to RTM - EF Core
 author: rowanmiller
 ms.author: divega
 

--- a/entity-framework/core/miscellaneous/testing/in-memory.md
+++ b/entity-framework/core/miscellaneous/testing/in-memory.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Testing with InMemory | Microsoft Docs
+title: Testing with InMemory - EF Core
 author: rowanmiller
 ms.author: divega
 

--- a/entity-framework/core/miscellaneous/testing/index.md
+++ b/entity-framework/core/miscellaneous/testing/index.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Test components using Entity Framework | Microsoft Docs
+title: Test components using Entity Framework - EF Core
 author: rowanmiller
 ms.author: divega
 

--- a/entity-framework/core/miscellaneous/testing/sqlite.md
+++ b/entity-framework/core/miscellaneous/testing/sqlite.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Testing with SQLite | Microsoft Docs
+title: Testing with SQLite - EF Core
 author: rowanmiller
 ms.author: divega
 

--- a/entity-framework/core/modeling/alternate-keys.md
+++ b/entity-framework/core/modeling/alternate-keys.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Alternate Keys | Microsoft Docs
+title: Alternate Keys - EF Core
 author: rowanmiller
 ms.author: divega
 

--- a/entity-framework/core/modeling/backing-field.md
+++ b/entity-framework/core/modeling/backing-field.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Backing Fields | Microsoft Docs
+title: Backing Fields - EF Core
 author: rowanmiller
 ms.author: divega
 

--- a/entity-framework/core/modeling/concurrency.md
+++ b/entity-framework/core/modeling/concurrency.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Concurrency Tokens | Microsoft Docs
+title: Concurrency Tokens - EF Core
 author: rowanmiller
 ms.author: divega
 

--- a/entity-framework/core/modeling/generated-properties.md
+++ b/entity-framework/core/modeling/generated-properties.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Generated Values | Microsoft Docs
+title: Generated Values - EF Core
 author: rowanmiller
 ms.author: divega
 ms.date: 10/27/2016

--- a/entity-framework/core/modeling/included-properties.md
+++ b/entity-framework/core/modeling/included-properties.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Including & Excluding Properties | Microsoft Docs
+title: Including & Excluding Properties - EF Core
 author: rowanmiller
 ms.author: divega
 

--- a/entity-framework/core/modeling/included-types.md
+++ b/entity-framework/core/modeling/included-types.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Including & Excluding Types | Microsoft Docs
+title: Including & Excluding Types - EF Core
 author: rowanmiller
 ms.author: divega
 

--- a/entity-framework/core/modeling/index.md
+++ b/entity-framework/core/modeling/index.md
@@ -1,5 +1,5 @@
 ﻿---
-title: EF Core | Creating a Model | Microsoft Docs
+title: Creating a Model - EF Core
 author: rowanmiller
 ms.author: divega
 

--- a/entity-framework/core/modeling/indexes.md
+++ b/entity-framework/core/modeling/indexes.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Indexes | Microsoft Docs
+title: Indexes - EF Core
 author: rowanmiller
 ms.author: divega
 

--- a/entity-framework/core/modeling/inheritance.md
+++ b/entity-framework/core/modeling/inheritance.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Inheritance | Microsoft Docs
+title: Inheritance - EF Core
 author: rowanmiller
 ms.author: divega
 

--- a/entity-framework/core/modeling/keys.md
+++ b/entity-framework/core/modeling/keys.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Keys (primary) | Microsoft Docs
+title: Keys (primary) - EF Core
 author: rowanmiller
 ms.author: divega
 

--- a/entity-framework/core/modeling/max-length.md
+++ b/entity-framework/core/modeling/max-length.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Maximum Length | Microsoft Docs
+title: Maximum Length - EF Core
 author: rowanmiller
 ms.author: divega
 

--- a/entity-framework/core/modeling/relational/columns.md
+++ b/entity-framework/core/modeling/relational/columns.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Column Mapping | Microsoft Docs
+title: Column Mapping - EF Core
 author: rowanmiller
 ms.author: divega
 

--- a/entity-framework/core/modeling/relational/computed-columns.md
+++ b/entity-framework/core/modeling/relational/computed-columns.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Computed Columns | Microsoft Docs
+title: Computed Columns - EF Core
 author: rowanmiller
 ms.author: divega
 

--- a/entity-framework/core/modeling/relational/data-types.md
+++ b/entity-framework/core/modeling/relational/data-types.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Data Types | Microsoft Docs
+title: Data Types - EF Core
 author: rowanmiller
 ms.author: divega
 

--- a/entity-framework/core/modeling/relational/default-schema.md
+++ b/entity-framework/core/modeling/relational/default-schema.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Default Schema | Microsoft Docs
+title: Default Schema - EF Core
 author: rowanmiller
 ms.author: divega
 

--- a/entity-framework/core/modeling/relational/default-values.md
+++ b/entity-framework/core/modeling/relational/default-values.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Default Values | Microsoft Docs
+title: Default Values - EF Core
 author: rowanmiller
 ms.author: divega
 

--- a/entity-framework/core/modeling/relational/fk-constraints.md
+++ b/entity-framework/core/modeling/relational/fk-constraints.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Foreign Key Constraints | Microsoft Docs
+title: Foreign Key Constraints - EF Core
 author: rowanmiller
 ms.author: divega
 

--- a/entity-framework/core/modeling/relational/index.md
+++ b/entity-framework/core/modeling/relational/index.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Relational Database Modeling | Microsoft Docs
+title: Relational Database Modeling - EF Core
 author: rowanmiller
 ms.author: divega
 

--- a/entity-framework/core/modeling/relational/indexes.md
+++ b/entity-framework/core/modeling/relational/indexes.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Indexes | Microsoft Docs
+title: Indexes - EF Core
 author: rowanmiller
 ms.author: divega
 

--- a/entity-framework/core/modeling/relational/inheritance.md
+++ b/entity-framework/core/modeling/relational/inheritance.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Inheritance (Relational Database) | Microsoft Docs
+title: Inheritance (Relational Database) - EF Core
 author: rowanmiller
 ms.author: divega
 

--- a/entity-framework/core/modeling/relational/primary-keys.md
+++ b/entity-framework/core/modeling/relational/primary-keys.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Primary Keys | Microsoft Docs
+title: Primary Keys - EF Core
 author: rowanmiller
 ms.author: divega
 

--- a/entity-framework/core/modeling/relational/sequences.md
+++ b/entity-framework/core/modeling/relational/sequences.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Sequences | Microsoft Docs
+title: Sequences - EF Core
 author: rowanmiller
 ms.author: divega
 

--- a/entity-framework/core/modeling/relational/tables.md
+++ b/entity-framework/core/modeling/relational/tables.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Table Mapping | Microsoft Docs
+title: Table Mapping - EF Core
 author: rowanmiller
 ms.author: divega
 

--- a/entity-framework/core/modeling/relational/unique-constraints.md
+++ b/entity-framework/core/modeling/relational/unique-constraints.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Alternate Keys (Unique Constraints) | Microsoft Docs
+title: Alternate Keys (Unique Constraints) - EF Core
 author: rowanmiller
 ms.author: divega
 

--- a/entity-framework/core/modeling/relationships.md
+++ b/entity-framework/core/modeling/relationships.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Relationships | Microsoft Docs
+title: Relationships - EF Core
 author: rowanmiller
 ms.author: divega
 ms.date: 10/27/2016

--- a/entity-framework/core/modeling/required-optional.md
+++ b/entity-framework/core/modeling/required-optional.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Required/optional properties | Microsoft Docs
+title: Required/optional properties - EF Core
 author: rowanmiller
 ms.author: divega
 

--- a/entity-framework/core/modeling/shadow-properties.md
+++ b/entity-framework/core/modeling/shadow-properties.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Shadow Properties | Microsoft Docs
+title: Shadow Properties - EF Core
 author: rowanmiller
 ms.author: divega
 

--- a/entity-framework/core/platforms/index.md
+++ b/entity-framework/core/platforms/index.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Supported .NET implementations | Microsoft Docs
+title: Supported .NET implementations - EF Core
 author: rowanmiller
 ms.author: divega
 ms.date: 08/30/2017

--- a/entity-framework/core/providers/devart/index.md
+++ b/entity-framework/core/providers/devart/index.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Devart Database Providers | Microsoft Docs
+title: Devart Database Providers - EF Core
 author: rowanmiller
 ms.author: divega
 

--- a/entity-framework/core/providers/ibm/index.md
+++ b/entity-framework/core/providers/ibm/index.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | IBM Data Server (DB2) Database Provider | Microsoft Docs
+title: IBM Data Server (DB2) Database Provider - EF Core
 author: rowanmiller
 ms.author: divega
 ms.date: 02/15/2017

--- a/entity-framework/core/providers/in-memory/index.md
+++ b/entity-framework/core/providers/in-memory/index.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | InMemory Database Provider | Microsoft Docs
+title: InMemory Database Provider - EF Core
 author: rowanmiller
 ms.author: divega
 

--- a/entity-framework/core/providers/index.md
+++ b/entity-framework/core/providers/index.md
@@ -1,5 +1,5 @@
 ﻿---
-title: EF Core | Database Providers | Microsoft Docs
+title: Database Providers - EF Core
 author: rowanmiller
 ms.author: divega
 

--- a/entity-framework/core/providers/my-cat/index.md
+++ b/entity-framework/core/providers/my-cat/index.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Pomelo MyCat Database Provider | Microsoft Docs
+title: Pomelo MyCat Database Provider - EF Core
 author: rowanmiller
 ms.author: divega
 ms.date: 02/27/2017

--- a/entity-framework/core/providers/mysql/index.md
+++ b/entity-framework/core/providers/mysql/index.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | MySQL Database Provider | Microsoft Docs
+title: MySQL Database Provider - EF Core
 author: rowanmiller
 ms.author: divega
 

--- a/entity-framework/core/providers/npgsql/index.md
+++ b/entity-framework/core/providers/npgsql/index.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Npgsql Database Provider for PostgreSQL | Microsoft Docs
+title: Npgsql Database Provider for PostgreSQL - EF Core
 author: rowanmiller
 ms.author: divega
 

--- a/entity-framework/core/providers/oracle/index.md
+++ b/entity-framework/core/providers/oracle/index.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Oracle Database Provider | Microsoft Docs
+title: Oracle Database Provider - EF Core
 author: rowanmiller
 ms.author: divega
 

--- a/entity-framework/core/providers/pomelo/index.md
+++ b/entity-framework/core/providers/pomelo/index.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Pomelo MySQL Database Provider | Microsoft Docs
+title: Pomelo MySQL Database Provider - EF Core
 author: rowanmiller
 ms.author: divega
 

--- a/entity-framework/core/providers/sql-compact/index.md
+++ b/entity-framework/core/providers/sql-compact/index.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Microsoft SQL Server Compact Edition Database Provider | Microsoft Docs
+title: Microsoft SQL Server Compact Edition Database Provider - EF Core
 author: rowanmiller
 ms.author: divega
 

--- a/entity-framework/core/providers/sql-server/index.md
+++ b/entity-framework/core/providers/sql-server/index.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Microsoft SQL Server Database Provider | Microsoft Docs
+title: Microsoft SQL Server Database Provider - EF Core
 author: rowanmiller
 ms.author: divega
 

--- a/entity-framework/core/providers/sql-server/memory-optimized-tables.md
+++ b/entity-framework/core/providers/sql-server/memory-optimized-tables.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Microsoft SQL Server Database Provider | Memory-Optimized Tables | Microsoft Docs
+title: Microsoft SQL Server Database Provider - Memory-Optimized Tables - EF Core
 author: rowanmiller
 ms.author: divega
 

--- a/entity-framework/core/providers/sqlite/index.md
+++ b/entity-framework/core/providers/sqlite/index.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | SQLite Database Provider | Microsoft Docs
+title: SQLite Database Provider - EF Core
 author: rowanmiller
 ms.author: divega
 

--- a/entity-framework/core/providers/sqlite/limitations.md
+++ b/entity-framework/core/providers/sqlite/limitations.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | SQLite Database Provider | Limitations | Microsoft Docs
+title: SQLite Database Provider - Limitations - EF Core
 author: rowanmiller
 ms.author: divega
 

--- a/entity-framework/core/providers/writing-a-provider.md
+++ b/entity-framework/core/providers/writing-a-provider.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Writing a Database Provider | Microsoft Docs
+title: Writing a Database Provider - EF Core
 author: anmiller
 ms.author: divega
 ms.date: 10/27/2016

--- a/entity-framework/core/querying/async.md
+++ b/entity-framework/core/querying/async.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Asynchronous Queries | Microsoft Docs
+title: Asynchronous Queries - EF Core
 author: rowanmiller
 ms.author: divega
 ms.date: 01/24/2017

--- a/entity-framework/core/querying/basic.md
+++ b/entity-framework/core/querying/basic.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Basic Queries | Microsoft Docs
+title: Basic Queries - EF Core
 author: rowanmiller
 ms.author: divega
 

--- a/entity-framework/core/querying/client-eval.md
+++ b/entity-framework/core/querying/client-eval.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Client vs. Server Evaluation | Microsoft Docs
+title: Client vs. Server Evaluation - EF Core
 author: rowanmiller
 ms.author: divega
 

--- a/entity-framework/core/querying/index.md
+++ b/entity-framework/core/querying/index.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Querying Data | Microsoft Docs
+title: Querying Data - EF Core
 author: rowanmiller
 ms.author: divega
 

--- a/entity-framework/core/querying/overview.md
+++ b/entity-framework/core/querying/overview.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | How Queries Work | Microsoft Docs
+title: How Queries Work - EF Core
 author: rowanmiller
 ms.author: divega
 ms.date: 10/27/2016

--- a/entity-framework/core/querying/raw-sql.md
+++ b/entity-framework/core/querying/raw-sql.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Raw SQL Queries | Microsoft Docs
+title: Raw SQL Queries - EF Core
 author: rowanmiller
 ms.author: divega
 

--- a/entity-framework/core/querying/related-data.md
+++ b/entity-framework/core/querying/related-data.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Loading Related Data | Microsoft Docs
+title: Loading Related Data - EF Core
 author: rowanmiller
 ms.author: divega
 ms.date: 10/27/2016

--- a/entity-framework/core/querying/tracking.md
+++ b/entity-framework/core/querying/tracking.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Tracking vs. No-Tracking Queries | Microsoft Docs
+title: Tracking vs. No-Tracking Queries - EF Core
 author: rowanmiller
 ms.author: divega
 

--- a/entity-framework/core/saving/async.md
+++ b/entity-framework/core/saving/async.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Asynchronous Saving | Microsoft Docs
+title: Asynchronous Saving - EF Core
 author: rowanmiller
 ms.author: divega
 ms.date: 01/24/2017

--- a/entity-framework/core/saving/basic.md
+++ b/entity-framework/core/saving/basic.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Basic Save | Microsoft Docs
+title: Basic Save - EF Core
 author: rowanmiller
 ms.author: divega
 

--- a/entity-framework/core/saving/cascade-delete.md
+++ b/entity-framework/core/saving/cascade-delete.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Cascade Delete | Microsoft Docs
+title: Cascade Delete - EF Core
 author: rowanmiller
 ms.author: divega
 

--- a/entity-framework/core/saving/concurrency.md
+++ b/entity-framework/core/saving/concurrency.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Handling Concurrency | Microsoft Docs
+title: Handling Concurrency - EF Core
 author: rowanmiller
 ms.author: divega
 

--- a/entity-framework/core/saving/disconnected-entities.md
+++ b/entity-framework/core/saving/disconnected-entities.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | 🔧 Disconnected Entities | Microsoft Docs
+title: 🔧 Disconnected Entities - EF Core
 author: rowanmiller
 ms.author: divega
 

--- a/entity-framework/core/saving/explicit-values-generated-properties.md
+++ b/entity-framework/core/saving/explicit-values-generated-properties.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Setting Explicit Values for Generated Properties | Microsoft Docs
+title: Setting Explicit Values for Generated Properties - EF Core
 author: rowanmiller
 ms.author: divega
 ms.date: 10/27/2016

--- a/entity-framework/core/saving/index.md
+++ b/entity-framework/core/saving/index.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Saving Data | Microsoft Docs
+title: Saving Data - EF Core
 author: rowanmiller
 ms.author: divega
 

--- a/entity-framework/core/saving/related-data.md
+++ b/entity-framework/core/saving/related-data.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Saving Related Data | Microsoft Docs
+title: Saving Related Data - EF Core
 author: rowanmiller
 ms.author: divega
 

--- a/entity-framework/core/saving/transactions.md
+++ b/entity-framework/core/saving/transactions.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | Transactions | Microsoft Docs
+title: Transactions - EF Core
 author: rowanmiller
 ms.author: divega
 

--- a/entity-framework/core/what-is-new/ef-core-1.0.md
+++ b/entity-framework/core/what-is-new/ef-core-1.0.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | What is new in EF Core 1.0 | Microsoft Docs
+title: What is new in EF Core 1.0 - EF Core
 author: divega
 ms.author: divega
 

--- a/entity-framework/core/what-is-new/ef-core-1.1.md
+++ b/entity-framework/core/what-is-new/ef-core-1.1.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | What is new in EF Core 1.1 | Microsoft Docs
+title: What is new in EF Core 1.1 - EF Core
 author: divega
 ms.author: divega
 

--- a/entity-framework/core/what-is-new/index.md
+++ b/entity-framework/core/what-is-new/index.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core | What is new in EF Core 2.0 | Microsoft Docs
+title: What is new in EF Core 2.0 - EF Core
 author: divega
 ms.author: divega
 

--- a/entity-framework/ef6/index.md
+++ b/entity-framework/ef6/index.md
@@ -1,5 +1,5 @@
 ---
-title: Entity Framework 6 | Microsoft Docs
+title: Entity Framework 6 
 author: rowanmiller
 ms.author: divega
 ms.date: 10/27/2016

--- a/entity-framework/efcore-and-ef6/choosing.md
+++ b/entity-framework/efcore-and-ef6/choosing.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core and EF6 | Which One Is Right for You | Microsoft Docs
+title: EF Core and EF6 - Which One Is Right for You
 author: rowanmiller
 ms.author: divega
 ms.date: 10/27/2016

--- a/entity-framework/efcore-and-ef6/features.md
+++ b/entity-framework/efcore-and-ef6/features.md
@@ -1,5 +1,5 @@
 ---
-title: EF Core & EF6 | Feature by Feature Comparison | Microsoft Docs
+title: EF Core & EF6 Feature by Feature Comparison 
 author: rowanmiller
 ms.author: divega
 ms.date: 10/27/2016

--- a/entity-framework/efcore-and-ef6/index.md
+++ b/entity-framework/efcore-and-ef6/index.md
@@ -1,5 +1,5 @@
 ---
-title: Compare EF Core & EF6 | Microsoft Docs
+title: Compare EF Core & EF6 
 author: rowanmiller
 ms.author: divega
 ms.date: 10/27/2016

--- a/entity-framework/efcore-and-ef6/porting/ensure-requirements.md
+++ b/entity-framework/efcore-and-ef6/porting/ensure-requirements.md
@@ -1,5 +1,5 @@
 ---
-title: Porting from EF6 to EF Core | Validate Requirements | Microsoft Docs
+title: Porting from EF6 to EF Core - Validate Requirements 
 author: rowanmiller
 ms.author: divega
 ms.date: 10/27/2016

--- a/entity-framework/efcore-and-ef6/porting/index.md
+++ b/entity-framework/efcore-and-ef6/porting/index.md
@@ -1,5 +1,5 @@
 ---
-title: Porting from EF6 to EF Core | Microsoft Docs
+title: Porting from EF6 to EF Core 
 author: rowanmiller
 ms.author: divega
 ms.date: 10/27/2016

--- a/entity-framework/efcore-and-ef6/porting/port-code.md
+++ b/entity-framework/efcore-and-ef6/porting/port-code.md
@@ -1,5 +1,5 @@
 ---
-title: Porting from EF6 to EF Core | Porting a Code-Based Model | Microsoft Docs
+title: Porting from EF6 to EF Core - Porting a Code-Based Model 
 author: rowanmiller
 ms.author: divega
 ms.date: 10/27/2016

--- a/entity-framework/efcore-and-ef6/porting/port-edmx.md
+++ b/entity-framework/efcore-and-ef6/porting/port-edmx.md
@@ -1,5 +1,5 @@
 ﻿---
-title: Porting from EF6 to EF Core | Porting an EDMX-Based Model | Microsoft Docs
+title: Porting from EF6 to EF Core - Porting an EDMX-Based Model 
 author: rowanmiller
 ms.author: divega
 ms.date: 10/27/2016

--- a/entity-framework/efcore-and-ef6/side-by-side.md
+++ b/entity-framework/efcore-and-ef6/side-by-side.md
@@ -1,5 +1,5 @@
 ---
-title: EF6 and EF Core | Using them in the Same Application | Microsoft Docs
+title: EF6 and EF Core - Using them in the Same Application 
 author: rowanmiller
 ms.author: divega
 ms.date: 10/27/2016

--- a/entity-framework/index.md
+++ b/entity-framework/index.md
@@ -1,6 +1,6 @@
 ---
 layout: HubPage
-title: Entity Framework | Microsoft Docs
+title: Entity Framework 
 author: rowanmiller
 ms.author: divega
 ms.date: 10/27/2016


### PR DESCRIPTION
Our BI reports were showing that a lot of topics under EF Core were all named EF Core. That was happening because OPS cuts the title when it sees a pipe.

I've also moved the "branding" towards the end of the title and removed | Microsoft Docs since the system adds that automatically.

This should also help with SEO since a lot of results were just EF Core because of that.

/cc @wadepickett 