### PR TITLE
Removing more anchors that are not rendering correctly

### DIFF
--- a/entity-framework/core/miscellaneous/cli/dotnet.md
+++ b/entity-framework/core/miscellaneous/cli/dotnet.md
@@ -358,8 +358,6 @@ Design-time tools attempt to automatically find how your application creates ins
 
 One of the solutions is to add an implementation of `IDesignTimeDbContextFactory<TContext>` to the current project. See [Using IDesignTimeDbContextFactory<TContext>](../configuring-dbcontext.md) for an example of how to create this factory.
 
-<a name=dotnet-cli-issues></a>
-
 ## .NET Standard Limitation
 
 .NET Core CLI does not fully support projects targeting .NET Standard class libraries. Despite being able to install EF tools, executing commands will show this warning message and may ultimately terminate in error.

--- a/entity-framework/core/miscellaneous/configuring-dbcontext.md
+++ b/entity-framework/core/miscellaneous/configuring-dbcontext.md
@@ -127,8 +127,6 @@ using (var context = serviceProvider.GetService<BloggingContext>())
 var options = serviceProvider.GetService<DbContextOptions<BloggingContext>>();
 ```
 
-<a name=use-idesigntimedbcontextfactory></a>
-
 ## Using `IDesignTimeDbContextFactory<TContext>`
 
 As an alternative to the options above, you may also provide an implementation of `IDesignTimeDbContextFactory<TContext>`. EF tools can use this factory to create an instance of your DbContext. This may be required in order to enable specific design-time experiences such as migrations.


### PR DESCRIPTION
It seems on docs.microsoft.com anchor tags (<a name="...">) only render correctly (i.e. invisible anchors) if the title that follows them does not have its own id. 

Otherwise the anchor is rendered as visible text and becomes non-functional.

We had two anchor tags that had this problem. One of them had an incoming link from our own documentation, which was fixed in to point to the actual id on the title after it in https://github.com/aspnet/EntityFramework.Docs/commit/79ccf63e2bea86f9d75dd5077ab972b64379ba3c.

There are two more anchor tags on the installation documentation which seem to still be working correctly so I am not touching them.