### PR TITLE
Fix breadcrum

### DIFF
--- a/entity-framework/docfx.json
+++ b/entity-framework/docfx.json
@@ -28,7 +28,6 @@
         "files": [
           "**.md",
           "**/toc.yml",
-          "toc.yml",
           "*.md"
         ],
         "exclude": [

--- a/entity-framework/docfx.json
+++ b/entity-framework/docfx.json
@@ -65,7 +65,7 @@
     ],
     "globalMetadata":
     {
-      "breadcrumb_path": "/breadcrumb/toc.json",
+      "breadcrumb_path": "/ef/breadcrumb/toc.json",
       "searchScope": ["Entity Framework"],
       "manager": "divega",
       "ms.topic": "article",


### PR DESCRIPTION
This makes docfx.json look a bit similar to ASP.NET docs. Changes were originally in an stale branch from @saldana which shows a more functional breadcrum in preview.