### PR TITLE
Fixing API reference links in ToC and root index

### DIFF
--- a/entity-framework/index.md
+++ b/entity-framework/index.md
@@ -221,16 +221,16 @@ uid: index
                                             </div>
                                             <div class="cardText">
                                                 <h3>
-                                                    <a href="https://docs.microsoft.com/ef/core/api">API Reference</a>
+                                                    <a href="https://docs.microsoft.com/dotnet/api/?view=efcore-2.0">⤤ API Reference</a>
                                                 </h3>
                                                 <p>
-                                                    <a href="/ef/core/api/microsoft.entityframeworkcore.dbcontext">DbContext</a>
+                                                    <a href="https://docs.microsoft.com/dotnet/api/microsoft.entityframeworkcore.dbcontext?view=efcore-2.0">⤤ DbContext</a>
                                                 </p>
                                                 <p>
-                                                    <a href="/ef/core/api/microsoft.entityframeworkcore.dbset-1">DbSet&lt;T&gt;</a>
+                                                    <a href="https://docs.microsoft.com/dotnet/api/microsoft.entityframeworkcore.dbset-1?view=efcore-2.0">⤤ DbSet&lt;TEntity&gt;</a>
                                                 </p>
                                                 <p>
-                                                    <a href="https://docs.microsoft.com/ef/core/api">more…</a>
+                                                    <a href="https://docs.microsoft.com/dotnet/api/?view=efcore-2.0">⤤ more…</a>
                                                 </p>
                                             </div>
                                         </div>

--- a/entity-framework/index.md
+++ b/entity-framework/index.md
@@ -224,13 +224,13 @@ uid: index
                                                     <a href="https://docs.microsoft.com/dotnet/api/?view=efcore-2.0">⤤ API Reference</a>
                                                 </h3>
                                                 <p>
-                                                    <a href="https://docs.microsoft.com/dotnet/api/microsoft.entityframeworkcore.dbcontext?view=efcore-2.0">⤤ DbContext</a>
+                                                    <a href="https://docs.microsoft.com/dotnet/api/microsoft.entityframeworkcore.dbcontext?view=efcore-2.0">DbContext</a>
                                                 </p>
                                                 <p>
-                                                    <a href="https://docs.microsoft.com/dotnet/api/microsoft.entityframeworkcore.dbset-1?view=efcore-2.0">⤤ DbSet&lt;TEntity&gt;</a>
+                                                    <a href="https://docs.microsoft.com/dotnet/api/microsoft.entityframeworkcore.dbset-1?view=efcore-2.0">DbSet&lt;TEntity&gt;</a>
                                                 </p>
                                                 <p>
-                                                    <a href="https://docs.microsoft.com/dotnet/api/?view=efcore-2.0">⤤ more…</a>
+                                                    <a href="https://docs.microsoft.com/dotnet/api/?view=efcore-2.0">more…</a>
                                                 </p>
                                             </div>
                                         </div>

--- a/entity-framework/toc.md
+++ b/entity-framework/toc.md
@@ -127,7 +127,7 @@
 #### [Upgrading from 1.0 RC2 to RTM](core/miscellaneous/rc2-rtm-upgrade.md)
 #### [Upgrading to EF Core 2.0](core/miscellaneous/1x-2x-upgrade.md)
 
-### [⤤ API Reference](https://docs.microsoft.com/en-us/dotnet/api/?view=efcore-2.0) 
+### [⤤ API Reference](https://docs.microsoft.com/dotnet/api/?view=efcore-2.0) 
 
 ## [Entity Framework 6](ef6/index.md)
 ### [⤤ Documentation](http://msdn.com/data/ef)


### PR DESCRIPTION
- Updating all links in root index page
- Adding external hint arrow ⤤ in root index page
- Removing en-us from the URL in ToC