### PR TITLE
Fixing various links

### DIFF
--- a/entity-framework/core/get-started/aspnetcore/new-db.md
+++ b/entity-framework/core/get-started/aspnetcore/new-db.md
@@ -122,6 +122,6 @@ Press F5 to run and test the app.
 ## Additional Resources
 
 * [EF - New database with SQLite](xref:core/get-started/netcore/new-db-sqlite) -  a cross-platform console EF tutorial.
-* [Introduction to ASP.NET Core MVC on Mac or Linux](https://docs.microsoft.com/en-us/aspnet/core/tutorials/first-mvc-app-xplat/index)
-* [Introduction to ASP.NET Core MVC with Visual Studio](https://docs.microsoft.com/en-us/aspnet/core/tutorials/first-mvc-app/index)
-* [Getting started with ASP.NET Core and Entity Framework Core using Visual Studio](https://docs.microsoft.com/en-us/aspnet/core/data/ef-mvc/index)
+* [Introduction to ASP.NET Core MVC on Mac or Linux](https://docs.microsoft.com/aspnet/core/tutorials/first-mvc-app-xplat/index)
+* [Introduction to ASP.NET Core MVC with Visual Studio](https://docs.microsoft.com/aspnet/core/tutorials/first-mvc-app/index)
+* [Getting started with ASP.NET Core and Entity Framework Core using Visual Studio](https://docs.microsoft.com/aspnet/core/data/ef-mvc/index)

--- a/entity-framework/core/get-started/full-dotnet/existing-db.md
+++ b/entity-framework/core/get-started/full-dotnet/existing-db.md
@@ -25,7 +25,7 @@ The following prerequisites are needed to complete this walkthrough:
 
 * [Latest version of NuGet Package Manager](https://dist.nuget.org/index.html)
 
-* [Latest version of Windows PowerShell](https://www.microsoft.com/en-us/download/details.aspx?id=40855)
+* [Latest version of Windows PowerShell](https://docs.microsoft.com/powershell/scripting/setup/installing-windows-powershell)
 
 * [Blogging database](#blogging-database)
 

--- a/entity-framework/core/get-started/full-dotnet/new-db.md
+++ b/entity-framework/core/get-started/full-dotnet/new-db.md
@@ -25,7 +25,7 @@ The following prerequisites are needed to complete this walkthrough:
 
 * [Latest version of NuGet Package Manager](https://dist.nuget.org/index.html)
 
-* [Latest version of Windows PowerShell](https://www.microsoft.com/en-us/download/details.aspx?id=40855)
+* [Latest version of Windows PowerShell](https://docs.microsoft.com/powershell/scripting/setup/installing-windows-powershell)
 
 ## Create a new project
 

--- a/entity-framework/core/get-started/install/index.md
+++ b/entity-framework/core/get-started/install/index.md
@@ -47,7 +47,7 @@ Besides the runtime libraries, you can install tools which make it easier to per
 <a name="cli"></a>
 ### Cross-platform development using the .NET Core Command Line Interface (CLI)
 
-To develop applications that target [.NET Core](https://www.microsoft.com/net/download/core) you can choose to use the [`dotnet` CLI commands](https://docs.microsoft.com/en-us/dotnet/core/tools/) in combination with your favorite text editor, or an Integrated Development Environment (IDE) such as Visual Studio, Visual Studio for Mac or Visual Studio Code.
+To develop applications that target [.NET Core](https://www.microsoft.com/net/download/core) you can choose to use the [`dotnet` CLI commands](https://docs.microsoft.com/dotnet/core/tools/) in combination with your favorite text editor, or an Integrated Development Environment (IDE) such as Visual Studio, Visual Studio for Mac or Visual Studio Code.
 
 > [!IMPORTANT]  
 > Applications that target .NET Core require specific versions of Visual Studio, e.g. .NET Core 1.x development requires Visual Studio 2017, while .NET Core 2.0 development requires Visual Studio 2017 version 15.3.
@@ -84,7 +84,7 @@ You can develop many different types of applications that target .NET Core, .NET
 
 There are two ways you can install an EF Core database provider in your application from Visual Studio:
 
-#### Using NuGet's [Package Manager User Interface](https://docs.microsoft.com/en-us/nuget/tools/package-manager-ui)
+#### Using NuGet's [Package Manager User Interface](https://docs.microsoft.com/nuget/tools/package-manager-ui)
 
 * Select on the menu **Project > Manage NuGet Packages**
 
@@ -92,7 +92,7 @@ There are two ways you can install an EF Core database provider in your applicat
 
 * Select the `Microsoft.EntityFrameworkCore.SqlServer` package and the desired version and confirm
 
-#### Using NuGet's [Package Manager Console (PMC)](https://docs.microsoft.com/en-us/nuget/tools/package-manager-console)
+#### Using NuGet's [Package Manager Console (PMC)](https://docs.microsoft.com/nuget/tools/package-manager-console)
 
 * Select on the menu **Tools > NuGet Package Manager > Package Manager Console**
 

--- a/entity-framework/core/get-started/netcore/new-db-sqlite.md
+++ b/entity-framework/core/get-started/netcore/new-db-sqlite.md
@@ -115,6 +115,6 @@ Once you have a model, you can use [migrations](https://docs.microsoft.com/aspne
 ## Additional Resources
 
 * [.NET Core - New database with SQLite](xref:core/get-started/netcore/new-db-sqlite) -  a cross-platform console EF tutorial.
-* [Introduction to ASP.NET Core MVC on Mac or Linux](https://docs.microsoft.com/en-us/aspnet/core/tutorials/first-mvc-app-xplat/index)
-* [Introduction to ASP.NET Core MVC with Visual Studio](https://docs.microsoft.com/en-us/aspnet/core/tutorials/first-mvc-app/index)
-* [Getting started with ASP.NET Core and Entity Framework Core using Visual Studio](https://docs.microsoft.com/en-us/aspnet/core/data/ef-mvc/index)
+* [Introduction to ASP.NET Core MVC on Mac or Linux](https://docs.microsoft.com/aspnet/core/tutorials/first-mvc-app-xplat/index)
+* [Introduction to ASP.NET Core MVC with Visual Studio](https://docs.microsoft.com/aspnet/core/tutorials/first-mvc-app/index)
+* [Getting started with ASP.NET Core and Entity Framework Core using Visual Studio](https://docs.microsoft.com/aspnet/core/data/ef-mvc/index)

--- a/entity-framework/core/get-started/uwp/getting-started.md
+++ b/entity-framework/core/get-started/uwp/getting-started.md
@@ -31,7 +31,7 @@ The following items are required to complete this walkthrough:
 
 * [Visual Studio 2017](https://www.visualstudio.com/downloads/)
 
-* The latest version of [Windows 10 Developer Tools](https://dev.windows.com/en-us/downloads)
+* The latest version of [Windows 10 Developer Tools](https://dev.windows.com/downloads)
 
 ## Create a new project
 

--- a/entity-framework/core/miscellaneous/1x-2x-upgrade.md
+++ b/entity-framework/core/miscellaneous/1x-2x-upgrade.md
@@ -32,7 +32,7 @@ Updating an existing application to EF Core 2.0 may require:
 > [!TIP]  
 > The adoption of this new pattern when updating applications to 2.0 is highly recommended and is required in order for product features like Entity Framework Core Migrations to work. The other common alternative is to [implement *IDesignTimeDbContextFactory\<TContext>*](configuring-dbcontext.md#using-idesigntimedbcontextfactorytcontext).
 
-2. Applications targeting ASP.NET Core 2.0 can use EF Core 2.0 without additional dependencies besides third party database providers. However, applications targeting previous versions of ASP.NET Core need to upgrade to ASP.NET Core 2.0 in order to use EF Core 2.0. For more details on upgrading ASP.NET Core applications to 2.0 see [the ASP.NET Core documentation on the subject](https://docs.microsoft.com/en-us/aspnet/core/migration/1x-to-2x/).
+2. Applications targeting ASP.NET Core 2.0 can use EF Core 2.0 without additional dependencies besides third party database providers. However, applications targeting previous versions of ASP.NET Core need to upgrade to ASP.NET Core 2.0 in order to use EF Core 2.0. For more details on upgrading ASP.NET Core applications to 2.0 see [the ASP.NET Core documentation on the subject](https://docs.microsoft.com/aspnet/core/migration/1x-to-2x/).
 
 ## Breaking Changes
 

--- a/entity-framework/core/miscellaneous/cli/powershell.md
+++ b/entity-framework/core/miscellaneous/cli/powershell.md
@@ -15,7 +15,7 @@ uid: core/miscellaneous/cli/powershell
 EF Core Package Manager Console Tools for Visual Studio
 
 > [!NOTE]  
-> The tools require the [latest version of Windows PowerShell](https://www.microsoft.com/en-us/download/details.aspx?id=50395)
+> The tools require the [latest version of Windows PowerShell](https://docs.microsoft.com/powershell/scripting/setup/installing-windows-powershell)
 
 ## Installation
 

--- a/entity-framework/core/miscellaneous/connection-strings.md
+++ b/entity-framework/core/miscellaneous/connection-strings.md
@@ -16,7 +16,7 @@ Most database providers require some form of connection string to connect to the
 
 ## .NET Framework Applications
 
-.NET Framework applications, such as WinForms, WPF, Console, and ASP.NET 4, have a tried and tested connection string pattern. The connection string should be added to your applications App.config file (Web.config if you are using ASP.NET). If your connection string contains sensitive information, such as username and password, you can protect the contents of the configuration file using [Protected Configuration](https://msdn.microsoft.com/en-us/library/53tyfkaw.aspx).
+.NET Framework applications, such as WinForms, WPF, Console, and ASP.NET 4, have a tried and tested connection string pattern. The connection string should be added to your applications App.config file (Web.config if you are using ASP.NET). If your connection string contains sensitive information, such as username and password, you can protect the contents of the configuration file using [Protected Configuration](https://msdn.microsoft.com/library/53tyfkaw.aspx).
 
 ``` xml
 <?xml version="1.0" encoding="utf-8"?>

--- a/entity-framework/core/miscellaneous/connection-strings.md
+++ b/entity-framework/core/miscellaneous/connection-strings.md
@@ -16,7 +16,7 @@ Most database providers require some form of connection string to connect to the
 
 ## .NET Framework Applications
 
-.NET Framework applications, such as WinForms, WPF, Console, and ASP.NET 4, have a tried and tested connection string pattern. The connection string should be added to your applications App.config file (Web.config if you are using ASP.NET). If your connection string contains sensitive information, such as username and password, you can protect the contents of the configuration file using [Protected Configuration](https://msdn.microsoft.com/library/53tyfkaw.aspx).
+.NET Framework applications, such as WinForms, WPF, Console, and ASP.NET 4, have a tried and tested connection string pattern. The connection string should be added to your applications App.config file (Web.config if you are using ASP.NET). If your connection string contains sensitive information, such as username and password, you can protect the contents of the configuration file using [Protected Configuration](https://docs.microsoft.com/dotnet/framework/data/adonet/connection-strings-and-configuration-files#encrypting-configuration-file-sections-using-protected-configuration).
 
 ``` xml
 <?xml version="1.0" encoding="utf-8"?>
@@ -49,7 +49,7 @@ public class BloggingContext : DbContext
 
 ## Universal Windows Platform (UWP)
 
-Connection strings in a UWP application are typically a SQLite connection that just specifies a local filename. They typically do not contain sensitive information, and do not need to be changed as an application is deployed. As such, these connection strings are usually fine to be left in code, as shown below. If you wish to move them out of code then UWP supports the concept of settings, see the [App Settings section of the UWP documentation](https://msdn.microsoft.com/windows/uwp/app-settings/store-and-retrieve-app-data) for details.
+Connection strings in a UWP application are typically a SQLite connection that just specifies a local filename. They typically do not contain sensitive information, and do not need to be changed as an application is deployed. As such, these connection strings are usually fine to be left in code, as shown below. If you wish to move them out of code then UWP supports the concept of settings, see the [App Settings section of the UWP documentation](https://docs.microsoft.com/windows/uwp/app-settings/store-and-retrieve-app-data) for details.
 
 ``` csharp
 public class BloggingContext : DbContext

--- a/entity-framework/core/modeling/backing-field.md
+++ b/entity-framework/core/modeling/backing-field.md
@@ -42,7 +42,7 @@ You can use the Fluent API to configure a backing field for a property.
 
 ### Controlling when the field is used
 
-You can configure when EF uses the field or property. See the [PropertyAccessMode enum](https://docs.microsoft.com/en-us/ef/core/api/microsoft.entityframeworkcore.metadata.propertyaccessmode) for the supported options.
+You can configure when EF uses the field or property. See the [PropertyAccessMode enum](https://docs.microsoft.com/dotnet/api/microsoft.entityframeworkcore.propertyaccessmode) for the supported options.
 
 [!code-csharp[Main](../../../samples/core/Modeling/FluentAPI/Samples/BackingFieldAccessMode.cs#Sample)]
 

--- a/entity-framework/core/platforms/index.md
+++ b/entity-framework/core/platforms/index.md
@@ -11,7 +11,7 @@ uid: core/platforms/index
 
 We want EF Core to be available anywhere you can write .NET code, and we're still working towards that goal. The following table provides guidance for each .NET implementation where we want to enable EF Core.
 
-EF Core 2.0 targets [.NET Standard 2.0](https://docs.microsoft.com/en-us/dotnet/standard/net-standard) and therefore requires .NET implementations that support it.
+EF Core 2.0 targets [.NET Standard 2.0](https://docs.microsoft.com/dotnet/standard/net-standard) and therefore requires .NET implementations that support it.
 
 | .NET implementation | Status | 1.x requires | 2.x requires
 |-|-|-|-

--- a/entity-framework/core/providers/sql-server/memory-optimized-tables.md
+++ b/entity-framework/core/providers/sql-server/memory-optimized-tables.md
@@ -17,7 +17,7 @@ uid: core/providers/sql-server/memory-optimized-tables
 >
 > This feature was introduced in EF Core 1.1.
 
-[Memory-Optimized Tables](https://msdn.microsoft.com/library/dn133165.aspx) are a feature of SQL Server where the entire table resides in memory. A second copy of the table data is maintained on disk, but only for durability purposes. Data in memory-optimized tables is only read from disk during database recovery. For example, after a server restart.
+[Memory-Optimized Tables](https://docs.microsoft.com/sql/relational-databases/in-memory-oltp/memory-optimized-tables) are a feature of SQL Server where the entire table resides in memory. A second copy of the table data is maintained on disk, but only for durability purposes. Data in memory-optimized tables is only read from disk during database recovery. For example, after a server restart.
 
 ## Configuring a memory-optimized table
 

--- a/entity-framework/core/providers/sql-server/memory-optimized-tables.md
+++ b/entity-framework/core/providers/sql-server/memory-optimized-tables.md
@@ -17,7 +17,7 @@ uid: core/providers/sql-server/memory-optimized-tables
 >
 > This feature was introduced in EF Core 1.1.
 
-[Memory-Optimized Tables](https://msdn.microsoft.com/en-us/library/dn133165.aspx) are a feature of SQL Server where the entire table resides in memory. A second copy of the table data is maintained on disk, but only for durability purposes. Data in memory-optimized tables is only read from disk during database recovery. For example, after a server restart.
+[Memory-Optimized Tables](https://msdn.microsoft.com/library/dn133165.aspx) are a feature of SQL Server where the entire table resides in memory. A second copy of the table data is maintained on disk, but only for durability purposes. Data in memory-optimized tables is only read from disk during database recovery. For example, after a server restart.
 
 ## Configuring a memory-optimized table
 

--- a/entity-framework/core/querying/async.md
+++ b/entity-framework/core/querying/async.md
@@ -10,7 +10,7 @@ uid: core/querying/async
 
 # Asynchronous Queries
 
-Asynchronous queries avoid blocking a thread while the query is executed in the database. This can be useful to avoid freezing the UI of a thick-client application. Asynchronous operations can also increase throughput in a web application, where the thread can be freed up to service other requests while the database operation completes. For more information, see [Asynchronous Programming in C#](https://msdn.microsoft.com/library/mt674882.aspx).
+Asynchronous queries avoid blocking a thread while the query is executed in the database. This can be useful to avoid freezing the UI of a thick-client application. Asynchronous operations can also increase throughput in a web application, where the thread can be freed up to service other requests while the database operation completes. For more information, see [Asynchronous Programming in C#](https://docs.microsoft.com/dotnet/csharp/async).
 
 > [!WARNING]  
 > EF Core does not support multiple parallel operations being run on the same context instance. You should always wait for an operation to complete before beginning the next operation. This is typically done by using the `await` keyword on each asynchronous operation.

--- a/entity-framework/core/querying/async.md
+++ b/entity-framework/core/querying/async.md
@@ -10,7 +10,7 @@ uid: core/querying/async
 
 # Asynchronous Queries
 
-Asynchronous queries avoid blocking a thread while the query is executed in the database. This can be useful to avoid freezing the UI of a thick-client application. Asynchronous operations can also increase throughput in a web application, where the thread can be freed up to service other requests while the database operation completes. For more information, see [Asynchronous Programming in C#](https://msdn.microsoft.com/en-us/library/mt674882.aspx).
+Asynchronous queries avoid blocking a thread while the query is executed in the database. This can be useful to avoid freezing the UI of a thick-client application. Asynchronous operations can also increase throughput in a web application, where the thread can be freed up to service other requests while the database operation completes. For more information, see [Asynchronous Programming in C#](https://msdn.microsoft.com/library/mt674882.aspx).
 
 > [!WARNING]  
 > EF Core does not support multiple parallel operations being run on the same context instance. You should always wait for an operation to complete before beginning the next operation. This is typically done by using the `await` keyword on each asynchronous operation.

--- a/entity-framework/core/saving/async.md
+++ b/entity-framework/core/saving/async.md
@@ -10,7 +10,7 @@ uid: core/saving/async
 
 # Asynchronous Saving
 
-Asynchronous saving avoids blocking a thread while the changes are written to the database. This can be useful to avoid freezing the UI of a thick-client application. Asynchronous operations can also increase throughput in a web application, where the thread can be freed up to service other requests while the database operation completes. For more information, see [Asynchronous Programming in C#](https://msdn.microsoft.com/library/mt674882.aspx).
+Asynchronous saving avoids blocking a thread while the changes are written to the database. This can be useful to avoid freezing the UI of a thick-client application. Asynchronous operations can also increase throughput in a web application, where the thread can be freed up to service other requests while the database operation completes. For more information, see [Asynchronous Programming in C#](https://docs.microsoft.com/dotnet/csharp/async).
 
 > [!WARNING]  
 > EF Core does not support multiple parallel operations being run on the same context instance. You should always wait for an operation to complete before beginning the next operation. This is typically done by using the `await` keyword on each asynchronous operation.

--- a/entity-framework/core/saving/async.md
+++ b/entity-framework/core/saving/async.md
@@ -10,7 +10,7 @@ uid: core/saving/async
 
 # Asynchronous Saving
 
-Asynchronous saving avoids blocking a thread while the changes are written to the database. This can be useful to avoid freezing the UI of a thick-client application. Asynchronous operations can also increase throughput in a web application, where the thread can be freed up to service other requests while the database operation completes. For more information, see [Asynchronous Programming in C#](https://msdn.microsoft.com/en-us/library/mt674882.aspx).
+Asynchronous saving avoids blocking a thread while the changes are written to the database. This can be useful to avoid freezing the UI of a thick-client application. Asynchronous operations can also increase throughput in a web application, where the thread can be freed up to service other requests while the database operation completes. For more information, see [Asynchronous Programming in C#](https://msdn.microsoft.com/library/mt674882.aspx).
 
 > [!WARNING]  
 > EF Core does not support multiple parallel operations being run on the same context instance. You should always wait for an operation to complete before beginning the next operation. This is typically done by using the `await` keyword on each asynchronous operation.

--- a/entity-framework/index.md
+++ b/entity-framework/index.md
@@ -263,7 +263,7 @@ uid: index
                                                     </div>
                                                 </div>
                                                 <div class="cardText">
-                                                    <h3>Get Started</h3>
+                                                    <h3>⤤ Get Started</h3>
                                                     <p>Learn how to access data with Entity Framework 6.</p>
                                                 </div>
                                             </div>
@@ -282,7 +282,7 @@ uid: index
                                                     </div>
                                                 </div>
                                                 <div class="cardText">
-                                                    <h3>API Reference</h3>
+                                                    <h3>⤤ API Reference</h3>
                                                     <p>Browse the Entity Framework 6 API, organized by namespace.</p>
                                                 </div>
                                             </div>

--- a/entity-framework/index.md
+++ b/entity-framework/index.md
@@ -224,10 +224,10 @@ uid: index
                                                     <a href="https://docs.microsoft.com/dotnet/api/?view=efcore-2.0">⤤ API Reference</a>
                                                 </h3>
                                                 <p>
-                                                    <a href="https://docs.microsoft.com/dotnet/api/microsoft.entityframeworkcore.dbcontext?view=efcore-2.0">DbContext</a>
+                                                    <a href="https://docs.microsoft.com/dotnet/api/microsoft.entityframeworkcore.dbcontext">DbContext</a>
                                                 </p>
                                                 <p>
-                                                    <a href="https://docs.microsoft.com/dotnet/api/microsoft.entityframeworkcore.dbset-1?view=efcore-2.0">DbSet&lt;TEntity&gt;</a>
+                                                    <a href="https://docs.microsoft.com/dotnet/api/microsoft.entityframeworkcore.dbset-1">DbSet&lt;TEntity&gt;</a>
                                                 </p>
                                                 <p>
                                                     <a href="https://docs.microsoft.com/dotnet/api/?view=efcore-2.0">more…</a>


### PR DESCRIPTION
- Removes unnecessary en-us from URLs
- Removes unnecessary ?view-efcore-2.0 from URLs
- Points links to documentation on how to install PowerShell instead of different PowerShell downloads
- Use existing docs.microsoft.com links instead of old msdn versions