### PR TITLE
L9084: Broken links

### DIFF
--- a/entity-framework/core/querying/filters.md
+++ b/entity-framework/core/querying/filters.md
@@ -23,6 +23,7 @@ The following example shows how to use Global Query Filters to implement soft-de
 First, define the entities:
 
 [!code-csharp[Main](../../../efcore-dev/samples/QueryFilters/Program.cs#Entities)]
+<!---Loc Comment: Links with the following reference: (../../../efcore-dev/samples/QueryFilters/Program.cs) are not working--->
 
 Note the declaration of a __tenantId_ field on the _Blog_ entity. This will be used to associate each Blog instance with a specific tenant. Also defined is an _IsDeleted_ property on the _Post_ entity type. This is used this to keep track of whether a _Post_ instance has been "soft-deleted". I.e. The instance is marked as deleted withouth physically removing the underlying data.
 


### PR DESCRIPTION
Hello, @anpete,

Localization team has reported source content issue that causes issue for localization.  It seems that there is no QueryFilters folder in source repo. So links like [!code-csharp[Main](../../../efcore-dev/samples/QueryFilters/Program.cs#Configuration)] are not working properly in target versions. 

Please, help to check my comment tag added into the article and reply with explanation if source text should be fixed, or it is by design. If fix is needed, please, let me know either if you would like me to fix it in this PR, or if you will fix it in another PR. In case of using another PR, please let me know of your PR number, so we can confirm and close this PR. 

Many thanks in advance.