### PR TITLE
L9434: Broken links

### DIFF
--- a/entity-framework/core/querying/filters.md
+++ b/entity-framework/core/querying/filters.md
@@ -23,6 +23,7 @@ The following example shows how to use Global Query Filters to implement soft-de
 First, define the entities:
 
 [!code-csharp[Main](../../../efcore-dev/samples/QueryFilters/Program.cs#Entities)]
+<!---Loc Comment: Links with the following reference: (../../../efcore-dev/samples/QueryFilters/Program.cs) are not working--->
 
 Note the declaration of a __tenantId_ field on the _Blog_ entity. This will be used to associate each Blog instance with a specific tenant. Also defined is an _IsDeleted_ property on the _Post_ entity type. This is used this to keep track of whether a _Post_ instance has been "soft-deleted". I.e. The instance is marked as deleted withouth physically removing the underlying data.
 


### PR DESCRIPTION
Hello, @divega @anpete,

I've opened this PR since the problem of PR #587 persits. The links to https://github.com/aspnet/EntityFramework.Docs/blob/live/efcore-dev/samples/QueryFilters/Program.cs seem to be wrong. There is no such include file anymore, it was probably moved. But there are several Program.cs files in github repo, so I do not know which one should be the correct one, which existed in the QueryFilter folder before.

Could you, please, check this again? Many thanks for your time in advance.