### PR TITLE
Add NeinLinq.EntityFrameworkCore to Tools & Extensions

### DIFF
--- a/entity-framework/core/extensions/neinlinq.md
+++ b/entity-framework/core/extensions/neinlinq.md
@@ -1,0 +1,18 @@
+---
+title: NeinLinq.EntityFrameworkCore - Tools & Extensions - EF Core
+author: axelheer
+ms.author: todo
+ms.date: 01/09/2018
+ms.assetid: 72FC66BB-856B-468C-975E-FD0C74196C20
+ms.technology: entity-framework-core
+uid: core/extensions/neinlinq
+---
+# NeinLinq.EntityFrameworkCore Extension
+
+> [!NOTE]  
+> This extension is not maintained as part of the Entity Framework Core project. When considering a third party extension, be sure to evaluate quality, licensing, support, etc. to ensure they meet your requirements.
+
+NeinLinq.EntityFrameworkCore provides helpful extensions for using LINQ providers such as Entity Framework that support only a minor subset of .NET functions, reusing functions, rewriting queries, even making them null-safe, and building dynamic queries using translatable predicates and selectors.
+
+The following resource will help you get started with NeinLinq.EntityFrameworkCore.
+* [NeinLinq.EntityFrameworkCore GitHub repository](https://github.com/axelheer/nein-linq/)

--- a/entity-framework/toc.md
+++ b/entity-framework/toc.md
@@ -129,6 +129,7 @@
 #### [Microsoft.EntityFrameworkCore.AutoHistory](core/extensions/autohistory.md)
 #### [Microsoft.EntityFrameworkCore.DynamicLinq](core/extensions/dynamiclinq.md)
 #### [Microsoft.EntityFrameworkCore.UnitOfWork](core/extensions/unitofwork.md)
+#### [NeinLinq.EntityFrameworkCore](core/extensions/neinlinq.md)
 
 ### Miscellaneous
 #### [Connection Strings](core/miscellaneous/connection-strings.md)


### PR DESCRIPTION
I'm not sure if there's some kind of process to add tools to the list (compare #353), but filing an issue asking for sending a PR feels a bit cumbersome. I even don't  know what qualifies a tool being added (hey, it's repo has > 100 stars) here...

Just let me know, if that works for you.


