### PR TITLE
Typo fix

### DIFF
--- a/entity-framework/core/modeling/query-types.md
+++ b/entity-framework/core/modeling/query-types.md
@@ -15,7 +15,7 @@ Query Types are read-only query result types that can be added to the EF Core mo
 
 They are conceptually similar to Entity Types in that:
 
-- They are POCO C# types that are added to the model, either in ```OnModelCreating``` using the ```ModelBuilder.Query``` method, or via a DbContext "set" property (for query types such a property is typed as ```DbQuery<T>``` rather that ```DbSet<T>```).
+- They are POCO C# types that are added to the model, either in ```OnModelCreating``` using the ```ModelBuilder.Query``` method, or via a DbContext "set" property (for query types such a property is typed as ```DbQuery<T>``` rather than ```DbSet<T>```).
 - They support much of the same mapping capabilities as regular entity types. For example, inheritance mapping, navigations (see limitiations below) and, on relational stores, the ability to configure the target database schema objects via ```ToTable```, ```HasColumn``` fluent-api methods (or data annotations).
 
 Query Types are different from entity types in that they:


### PR DESCRIPTION
Changed the word "that" to "than" in the following sentence:
(for query types such a property is typed as `DbQuery<T>` rather that `DbSet<T>`)