### PR TITLE
Experiment: Moving roadmap and other wiki content to docs

### DIFF
--- a/entity-framework/core/what-is-new/index.md
+++ b/entity-framework/core/what-is-new/index.md
@@ -17,16 +17,14 @@ You can use the links below to learn about new features in each release:
 
 ## Future releases
 
-- [Entity Framework Core Roadmap](xref:core/what-is-new/roadmap)
+- [EF Core Roadmap](xref:core/what-is-new/roadmap)
 
 ## Recent releases
 
-- [EF Core 2.1](xref:core/what-is-new/ef-core-2.1): Currently in preview.
-
-- [EF Core 2.0](xref:core/what-is-new/ef-core-2.0): The latest released version.
+- [EF Core 2.1 (currently in preview)](xref:core/what-is-new/ef-core-2.1)
+- [EF Core 2.0 (latest released version)](xref:core/what-is-new/ef-core-2.0)
 
 ## Past releases
 
 - [EF Core 1.1](xref:core/what-is-new/ef-core-1.1)
-
 - [EF Core 1.0](xref:core/what-is-new/ef-core-1.0)

--- a/entity-framework/core/what-is-new/index.md
+++ b/entity-framework/core/what-is-new/index.md
@@ -15,13 +15,17 @@ uid: core/what-is-new/index
 
 You can use the links below to learn about new features in each release:
 
+## Future releases
+
+- [Entity Framework Core Roadmap](xref:core/what-is-new/roadmap)
+
 ## Recent releases
 
 - [EF Core 2.1](xref:core/what-is-new/ef-core-2.1): Currently in preview.
 
 - [EF Core 2.0](xref:core/what-is-new/ef-core-2.0): The latest released version.
 
-## Past versions
+## Past releases
 
 - [EF Core 1.1](xref:core/what-is-new/ef-core-1.1)
 

--- a/entity-framework/core/what-is-new/roadmap.md
+++ b/entity-framework/core/what-is-new/roadmap.md
@@ -14,35 +14,29 @@ uid: core/what-is-new/roadmap
 # Entity Framework Core Roadmap
 
 > [!IMPORTANT]
-> Please note that the feature sets and schedules of future releases are always subject to change, and although we will try to keep this page up to date, it may not always reflect our latest plans at all times.
-
-## Schedule
-
-The schedule for EF Core is in-sync with the [.NET Core](https://github.com/dotnet/core/blob/master/roadmap.md) and [ASP.NET Core schedule](https://github.com/aspnet/Home/wiki/Roadmap).
-
-### Next release: EF Core 2.1
+> Please note that the feature sets and schedules of future releases are always subject to change, and although we will try to keep this page up to date, it may not reflect our latest plans at all times.
 
 The first preview of EF Core 2.1 was released on February 2018, therefore for more information on the feature set included, you can see [What is new in EF Core 2.1](xref:core/what-is-new/ef-core-2.1).
 
 We intend to release additional previews monthly, and a final release of 2.1 on the second calendar quarter of 2018.
 
-### Future releases
+We have not completed the [release planning](#release-planning-process) for the next release after EF Core 2.1.
 
-We have not completed the [release planning](#release-planning-process) for the next release after EF Core 2.1, and we have not decided what version it will use.
+## Schedule
+
+The schedule for EF Core is in-sync with the [.NET Core schedule](https://github.com/dotnet/core/blob/master/roadmap.md) and [ASP.NET Core schedule](https://github.com/aspnet/Home/wiki/Roadmap).
 
 ## Backlog
 
 We use the [Backlog Milestone](https://github.com/aspnet/EntityFrameworkCore/issues?q=is%3Aopen+is%3Aissue+milestone%3ABacklog+sort%3Areactions-%2B1-desc) in our issue tracker to maintain a detailed list of issues and features. Customers can comment and up-vote these.
 
-We tend to leave issues open that we reasonably expect we will work on at some point, or that someone from the community could tackle, but that does not imply the intent to resolve them in a specific timeframe until we assign them to a specific milestone as part of our [release planning process](#release-planning-process).
+We tend to leave issues open that we reasonably expect we will work on at some point, or that someone from the community could tackle, but that does not imply the intent to resolve them in a specific timeframe until we assign them to a specific milestone as part of our [release planning process](#release-planning-process). If we do not plan to ever implement a feature, we will likely close the issue.
 
-Even then, plans can change: Priorities can change, release schedules change, resources change… As in all software projects, everything is subject to change. We don’t have enough information about the future to be able to say that feature X will be resolved by time/release Y. But if we plan to never implement a feature, then we’ll close the issue. So if an issue is open, then we likely plan to get to it at some point.
-
-Because EF Core is a new codebase, the presence of a feature in Entity Framework 6 does not mean that the feature is implemented in EF Core. For more information, see [Compare EF Core & EF6](xref:efcore-and-ef6/index)
+All that said, plans can change: priorities can change, release schedules change, resources change… As in all software projects, everything is subject to change. We don’t have enough information about the future to be able to say that feature X will be resolved by time/release Y. Even an issue that we closed can be reconsidered at a later point if we obtain new information about it.
 
 ## Release planning process
 
-We often get questions about how we choose specific features to go into a particular release. Our backlog certainly does not automatically translate into release plans.
+We often get questions about how we choose specific features to go into a particular release. Our backlog certainly does not automatically translate into release plans. The presence of a feature in EF6 also does not automatically mean that the feature needs to be implemented in EF Core.
 
 It is difficult to detail here the whole process we follow to plan a release, partly because a lot of it is discussing the specific features, opportunities and priorities, and partly because the process itself usually evolves with every release. However, it is relatively easy to summarize the common questions we try to answer when deciding what to work on next:
 
@@ -58,4 +52,4 @@ It is difficult to detail here the whole process we follow to plan a release, pa
 
 6. **What are the capabilities of the people available to work on a feature, and how to best leverage these resources?** Each member of the EF team and even our community contributors have different levels of experience in different areas and we have to plan accordingly. Even if we wanted to have “all hands on deck” to work on a specific feature like GroupBy translations, or many-to-many, that wouldn’t be practical.
 
-In the future we would like to add more opportunities for members of the developer community to provide inputs into release plans, e.g. by making it easier to review proposed drafts of the features and of the release plan itself.
+As mentioned before, this process evolves on every release, and in the future we would like to add more opportunities for members of the developer community to provide inputs into release plans, e.g. by making it easier to review proposed drafts of the features and of the release plan itself.

--- a/entity-framework/core/what-is-new/roadmap.md
+++ b/entity-framework/core/what-is-new/roadmap.md
@@ -16,11 +16,11 @@ uid: core/what-is-new/roadmap
 > [!IMPORTANT]
 > Please note that the feature sets and schedules of future releases are always subject to change, and although we will try to keep this page up to date, it may not reflect our latest plans at all times.
 
-The first preview of EF Core 2.1 was released on February 2018, therefore for more information on the feature set included, you can see [What is new in EF Core 2.1](xref:core/what-is-new/ef-core-2.1).
+The first preview of EF Core 2.1 was released on February 2018. You can now find more information about this release in [What is new in EF Core 2.1](xref:core/what-is-new/ef-core-2.1).
 
-We intend to release additional previews monthly, and a final release of 2.1 on the second calendar quarter of 2018.
+We intend to release additional previews of EF Core 2.1 monthly, and a final release on the second calendar quarter of 2018.
 
-We have not completed the [release planning](#release-planning-process) for the next release after EF Core 2.1.
+We have not completed the [release planning](#release-planning-process) for the next release after 2.1.
 
 ## Schedule
 
@@ -30,9 +30,11 @@ The schedule for EF Core is in-sync with the [.NET Core schedule](https://github
 
 We use the [Backlog Milestone](https://github.com/aspnet/EntityFrameworkCore/issues?q=is%3Aopen+is%3Aissue+milestone%3ABacklog+sort%3Areactions-%2B1-desc) in our issue tracker to maintain a detailed list of issues and features. Customers can comment and up-vote these.
 
-We tend to leave issues open that we reasonably expect we will work on at some point, or that someone from the community could tackle, but that does not imply the intent to resolve them in a specific timeframe until we assign them to a specific milestone as part of our [release planning process](#release-planning-process). If we do not plan to ever implement a feature, we will likely close the issue.
+We tend to leave issues open that we reasonably expect we will work on at some point, or that someone from the community could tackle, but that does not imply the intent to resolve them in a specific timeframe until we assign them to a specific milestone as part of our [release planning process](#release-planning-process).
 
-All that said, plans can change: priorities can change, release schedules change, resources change… As in all software projects, everything is subject to change. We don’t have enough information about the future to be able to say that feature X will be resolved by time/release Y. Even an issue that we closed can be reconsidered at a later point if we obtain new information about it.
+If we do not plan to ever implement a feature, we will likely close the issue. An issue that we closed can be reconsidered at a later point if we obtain new information about it.
+
+All that said, we don’t have enough information about the future to be able to say that feature X will be resolved by time/release Y. As in all software projects, priorities, release schedules, and available resources can change at any point.
 
 ## Release planning process
 

--- a/entity-framework/core/what-is-new/roadmap.md
+++ b/entity-framework/core/what-is-new/roadmap.md
@@ -1,0 +1,61 @@
+---
+title: Entity Framework Core Roadmap
+author: divega
+ms.author: divega
+
+ms.date: 02/20/2018
+
+ms.assetid: 834C9729-7F6E-4355-917D-DE3EE9FE149E
+ms.technology: entity-framework-core
+
+uid: core/what-is-new/roadmap
+---
+
+# Entity Framework Core Roadmap
+
+> [!IMPORTANT]
+> Please note that the feature sets and schedules of future releases are always subject to change, and although we will try to keep this page up to date, it may not always reflect our latest plans at all times.
+
+## Schedule
+
+The schedule for EF Core is in-sync with the [.NET Core](https://github.com/dotnet/core/blob/master/roadmap.md) and [ASP.NET Core schedule](https://github.com/aspnet/Home/wiki/Roadmap).
+
+### Next release: EF Core 2.1
+
+The first preview of EF Core 2.1 was released on February 2018, therefore for more information on the feature set included, you can see [What is new in EF Core 2.1](xref:core/what-is-new/ef-core-2.1).
+
+We intend to release additional previews monthly, and a final release of 2.1 on the second calendar quarter of 2018.
+
+### Future releases
+
+We have not completed the [release planning](#release-planning-process) for the next release after EF Core 2.1, and we have not decided what version it will use.
+
+## Backlog
+
+We use the [Backlog Milestone](https://github.com/aspnet/EntityFrameworkCore/issues?q=is%3Aopen+is%3Aissue+milestone%3ABacklog+sort%3Areactions-%2B1-desc) in our issue tracker to maintain a detailed list of issues and features. Customers can comment and up-vote these.
+
+We tend to leave issues open that we reasonably expect we will work on at some point, or that someone from the community could tackle, but that does not imply the intent to resolve them in a specific timeframe until we assign them to a specific milestone as part of our [release planning process](#release-planning-process).
+
+Even then, plans can change: Priorities can change, release schedules change, resources change… As in all software projects, everything is subject to change. We don’t have enough information about the future to be able to say that feature X will be resolved by time/release Y. But if we plan to never implement a feature, then we’ll close the issue. So if an issue is open, then we likely plan to get to it at some point.
+
+Because EF Core is a new codebase, the presence of a feature in Entity Framework 6 does not mean that the feature is implemented in EF Core. For more information, see [Compare EF Core & EF6](xref:efcore-and-ef6/index)
+
+## Release planning process
+
+We often get questions about how we choose specific features to go into a particular release. Our backlog certainly does not automatically translate into release plans.
+
+It is difficult to detail here the whole process we follow to plan a release, partly because a lot of it is discussing the specific features, opportunities and priorities, and partly because the process itself usually evolves with every release. However, it is relatively easy to summarize the common questions we try to answer when deciding what to work on next:
+
+1. **How many developers we think will use the feature and how much better will it make their applications/experience?** We aggregate feedback from many sources into this — Comments and votes on issues is one of those sources.
+
+2. **What are the workarounds people can use if we don’t implement this feature yet?** For example, many developers are able to map a join table in order to work around lack of native many-to-many support. Obviously, not all developers can do this, but many can, and this is a factor which counts.
+
+3. **Does implementing this feature evolve the architecture of EF Core such that it moves us closer to implementing other features?** We tend to favor features that act as building blocks for other features—for example, the table splitting that was done for owned types helps us move towards TPT support.
+
+4. **Is the feature an extensibility point?** We tend to favor extensibility points because they enable developers to more easily hook in their own behaviors and get some of the missing functionality that way. We’re planning to do some of this as a start to the lazy loading work.
+
+5. **What is the synergy of the feature when used in combination with other products?** We tend to favor features that allow EF Core to be used with other products or to significantly improve the experience of using other products, such as .NET Core, the latest version of Visual Studio, Microsoft Azure, etc.
+
+6. **What are the capabilities of the people available to work on a feature, and how to best leverage these resources?** Each member of the EF team and even our community contributors have different levels of experience in different areas and we have to plan accordingly. Even if we wanted to have “all hands on deck” to work on a specific feature like GroupBy translations, or many-to-many, that wouldn’t be practical.
+
+In the future we would like to add more opportunities for members of the developer community to provide inputs into release plans, e.g. by making it easier to review proposed drafts of the features and of the release plan itself.

--- a/entity-framework/efcore-and-ef6/choosing.md
+++ b/entity-framework/efcore-and-ef6/choosing.md
@@ -13,13 +13,11 @@ The following information will help you choose between Entity Framework Core and
 
 ## Guidance for new applications
 
-Because EF Core is a new product, and still lacks some critical O/RM features, EF6 will still be the most suitable choice for many applications.
+Consider using EF Core for new applications if you want to take advantage of the all the capabilities of EF Core and your application does not require any features that are not yet implemented in EF Core.
 
-**These are the types of applications we would recommend using EF Core for:**
+EF6 requires .NET Framework 4.0 (or a later version) and is only supported on Windows (i.e. it does not run on .NET Core and is not supported in other operating systems), but it is still a viable choice for new applications as long those constraints are acceptable and the application does not require new features in EF Core that are not available to EF6.
 
-* New applications that do not require features that are not yet implemented in EF Core. Review [Feature Comparison](features.md) to see if EF Core may be a suitable choice for your application.
-
-* Applications that target .NET Core, such as Universal Windows Platform (UWP) and ASP.NET Core applications. These applications can not use EF6 as it requires the .NET Framework (i.e. .NET Framework 4.5).
+Review [Feature Comparison](features.md) to see if EF Core may be a suitable choice for your application.
 
 ## Guidance for existing EF6 applications
 

--- a/entity-framework/efcore-and-ef6/index.md
+++ b/entity-framework/efcore-and-ef6/index.md
@@ -1,5 +1,5 @@
 ---
-title: Compare EF Core & EF6 
+title: Compare EF Core & EF6
 author: rowanmiller
 ms.author: divega
 ms.date: 10/27/2016
@@ -10,11 +10,11 @@ uid: efcore-and-ef6/index
 
 # Compare EF Core & EF6
 
-There are two versions of Entity Framework, Entity Framework Core and Entity Framework 6.
+There are two different versions of Entity Framework, Entity Framework Core and Entity Framework 6.
 
 ## Entity Framework 6
 
-Entity Framework 6 (EF6) is a tried and tested data access technology with many years of features and stabilization. It first released in 2008, as part of .NET Framework 3.5 SP1 and Visual Studio 2008 SP1. Starting with the EF4.1 release it has shipped as the [EntityFramework NuGet package](https://www.nuget.org/packages/EntityFramework/) - currently the most popular package on NuGet.org.
+Entity Framework 6 (EF6) is a tried and tested data access technology with many years of features and stabilization. It first released in 2008, as part of .NET Framework 3.5 SP1 and Visual Studio 2008 SP1. Starting with the EF4.1 release it has shipped as the [EntityFramework NuGet package](https://www.nuget.org/packages/EntityFramework/) - currently on of the most popular packages on NuGet.org.
 
 EF6 continues to be a supported product, and will continue to see bug fixes and minor improvements for some time to come.
 
@@ -22,6 +22,6 @@ EF6 continues to be a supported product, and will continue to see bug fixes and 
 
 Entity Framework Core (EF Core) is a lightweight, extensible, and cross-platform version of Entity Framework. EF Core introduces many improvements and new features when compared with EF6. At the same time, EF Core is a new code base and not as mature as EF6.
 
-EF Core keeps the developer experience from EF6, and most of the top-level APIs remain the same too, so EF Core will feel very familiar to folks who have used EF6. At the same time, EF Core is built over a completely new set of core components. This means EF Core doesn't automatically inherit all the features from EF6. Some of these features will show up in future releases (such as lazy loading and connection resiliency), other less commonly used features will not be implemented in EF Core.
+EF Core keeps the developer experience from EF6, and most of the top-level APIs remain the same too, so EF Core will feel very familiar to folks who have used EF6. At the same time, EF Core is built over a completely new set of core components. This means EF Core doesn't automatically inherit all the features from EF6. While some of these features will show up in future releases, other less commonly used features will not be implemented in EF Core.
 
-The new, extensible, and lightweight core has also allowed us to add some features to EF Core that will not be implemented in EF6 (such as alternate keys and mixed client/database evaluation in LINQ queries).
+The new, extensible, and lightweight core has also allowed us to add some features to EF Core that will not be implemented in EF6 (such as alternate keys, batch updates, and mixed client/database evaluation in LINQ queries).

--- a/entity-framework/efcore-and-ef6/index.md
+++ b/entity-framework/efcore-and-ef6/index.md
@@ -14,7 +14,7 @@ There are two different versions of Entity Framework, Entity Framework Core and 
 
 ## Entity Framework 6
 
-Entity Framework 6 (EF6) is a tried and tested data access technology with many years of features and stabilization. It first released in 2008, as part of .NET Framework 3.5 SP1 and Visual Studio 2008 SP1. Starting with the EF4.1 release it has shipped as the [EntityFramework NuGet package](https://www.nuget.org/packages/EntityFramework/) - currently on of the most popular packages on NuGet.org.
+Entity Framework 6 (EF6) is a tried and tested data access technology with many years of features and stabilization. It first released in 2008, as part of .NET Framework 3.5 SP1 and Visual Studio 2008 SP1. Starting with the EF4.1 release it has shipped as the [EntityFramework NuGet package](https://www.nuget.org/packages/EntityFramework/) - currently one of the most popular packages on NuGet.org.
 
 EF6 continues to be a supported product, and will continue to see bug fixes and minor improvements for some time to come.
 

--- a/entity-framework/toc.md
+++ b/entity-framework/toc.md
@@ -13,10 +13,11 @@
 ## [Entity Framework Core](core/index.md)
 
 ### [New in EF Core](core/what-is-new/index.md)
+#### [EF Core Roadmap](core/what-is-new/roadmap.md)
 #### [EF Core 2.1 (in preview)](core/what-is-new/ef-core-2.1.md)
-#### [EF Core 2.0 (latest released)](core/what-is-new/ef-core-2.0.md)
-#### [EF Core 1.1 (previous version)](core/what-is-new/ef-core-1.1.md)
-#### [EF Core 1.0 (previous version)](core/what-is-new/ef-core-1.0.md)
+#### [EF Core 2.0 (latest release)](core/what-is-new/ef-core-2.0.md)
+#### [EF Core 1.1](core/what-is-new/ef-core-1.1.md)
+#### [EF Core 1.0](core/what-is-new/ef-core-1.0.md)
 
 ### [Getting Started](core/get-started/index.md)
 #### [Installing EF Core](core/get-started/install/index.md)


### PR DESCRIPTION
Fixes https://github.com/aspnet/EntityFrameworkCore/issues/9615.

The current roadmap in the product's repo wiki is out of date.

Wanted to see how moving the roadmap to become part of our documentation (alongside the release history) feels and look like.

If we go ahead with this, I will replace the existing pages in the docs with links to the documentation.

Note that here I also moved an explanation about the backlog (that was part of the roadmap wiki page) and the release planning process content here.

I have also removed "critical" and "high priority" lists that as explained in #9615, have become the source of confusion.

Open to suggestions.