### PR TITLE
Removing project.json notices

### DIFF
--- a/entity-framework/core/get-started/aspnetcore/existing-db.md
+++ b/entity-framework/core/get-started/aspnetcore/existing-db.md
@@ -10,9 +10,6 @@ uid: core/get-started/aspnetcore/existing-db
 
 # Getting Started with EF Core on ASP.NET Core with an Existing Database
 
-> [!IMPORTANT]  
-> The [.NET Core SDK](https://www.microsoft.com/net/download/core) no longer supports `project.json` or Visual Studio 2015. Everyone doing .NET Core development is encouraged to [migrate from project.json to csproj](https://docs.microsoft.com/dotnet/articles/core/migration/) and [Visual Studio 2017](https://www.visualstudio.com/downloads/).
-
 In this walkthrough, you will build an ASP.NET Core MVC application that performs basic data access using Entity Framework. You will use reverse engineering to create an Entity Framework model based on an existing database.
 
 > [!TIP]  

--- a/entity-framework/core/get-started/netcore/new-db-sqlite.md
+++ b/entity-framework/core/get-started/netcore/new-db-sqlite.md
@@ -15,9 +15,6 @@ uid: core/get-started/netcore/new-db-sqlite
 
 In this walkthrough, you will create a .NET Core console app that performs basic data access against a SQLite database using Entity Framework Core. You will use migrations to create the database from your model. See [ASP.NET Core - New database](xref:core/get-started/aspnetcore/new-db) for a Visual Studio version using ASP.NET Core MVC.
 
-> [!NOTE]  
-> The [.NET Core SDK](https://www.microsoft.com/net/download/core) no longer supports `project.json` or Visual Studio 2015. We recommend you [migrate from project.json to csproj](https://docs.microsoft.com/dotnet/articles/core/migration/). If you are using Visual Studio, we recommend you migrate to [Visual Studio 2017](https://www.visualstudio.com/downloads/).
-
 > [!TIP]  
 > You can view this article's [sample](https://github.com/aspnet/EntityFramework.Docs/tree/master/samples/core/GetStarted/NetCore/ConsoleApp.SQLite) on GitHub.
 

--- a/entity-framework/core/miscellaneous/rc2-rtm-upgrade.md
+++ b/entity-framework/core/miscellaneous/rc2-rtm-upgrade.md
@@ -68,6 +68,9 @@ If you were targeting .NET Core with RC2, you needed to add `imports` to project
 }
 ```
 
+> [!NOTE]  
+> As of version 1.0 RTM, the [.NET Core SDK](https://www.microsoft.com/net/download/core) no longer supports `project.json` or developing .NET Core applications using Visual Studio 2015. We recommend you [migrate from project.json to csproj](https://docs.microsoft.com/dotnet/articles/core/migration/). If you are using Visual Studio, we recommend you upgrade to [Visual Studio 2017](https://www.visualstudio.com/downloads/).
+
 ## UWP: Add binding redirects
 
 Attempting to run EF commands on Universal Windows Platform (UWP) projects results in the following error:


### PR DESCRIPTION
Fixes #608. At this point these are noise in the tutorials. But I left a note in the page that is about upgrading to 1.0 RTM (although that was originally for the runtime only).