### PR TITLE
Added definition for `enum OrderStatus` in later examples.

### DIFF
--- a/entity-framework/core/modeling/owned-entities.md
+++ b/entity-framework/core/modeling/owned-entities.md
@@ -124,6 +124,12 @@ public class OrderDetails
     public StreetAddress ShippingAddress { get; set; }
 }
 
+public enum OrderStatus
+{
+    Pending,
+    Shipped
+}
+
 public class StreetAddress
 {
     public string Street { get; set; }


### PR DESCRIPTION
Simple edit that bothered me. It made the example in `Querying owned types` a tid-bit confusing, since it wasn't obvious at first that `OrderStatus` was an enum.