### PR TITLE
Signal the implications of not moving migrations

### DIFF
--- a/entity-framework/core/managing-schemas/migrations/projects.md
+++ b/entity-framework/core/managing-schemas/migrations/projects.md
@@ -17,7 +17,9 @@ To do this...
 2. Add a reference to your DbContext assembly.
 
 3. Move the migrations and model snapshot files to the class library.
-   * If you haven't added any, add one to the DbContext project then move it.
+   > [!TIP]
+   > If you have no existing migrations, generate one in the project containing the DbContext then move it. 
+   > This is important because if the migrations assembly does not contain an existing migration, the Add-Migration command will be unable to find the DbContext.
 
 4. Configure the migrations assembly:
 
@@ -32,7 +34,7 @@ To do this...
 
      ``` xml
      <PropertyGroup>
-       <OutputPath>..\MyStarupProject\bin\$(Configuration)\</OutputPath>
+       <OutputPath>..\MyStartupProject\bin\$(Configuration)\</OutputPath>
      </PropertyGroup>
      ```
 


### PR DESCRIPTION
EF Core - Migrations - Separate project

1) When attempting to have migrations in a seperate project, the migrations assembly must contain at least one migration in order for the Add-Migrations command to find the DbContext.
This PR attempts to make the implication of not doing so more clear, as well as making it easier to find why things are breaking when you try to do this for an empty project.

2) Fix a typo in MyStarupProject