### PR TITLE
Updated example of adding a package using the command 'dotnet add package' to include proper usage syntax.

### DIFF
--- a/entity-framework/core/get-started/netcore/new-db-sqlite.md
+++ b/entity-framework/core/get-started/netcore/new-db-sqlite.md
@@ -34,8 +34,8 @@ To use EF Core, install the package for the database provider(s) you want to tar
 * Install Microsoft.EntityFrameworkCore.Sqlite and Microsoft.EntityFrameworkCore.Design
 
   ```Console
-  dotnet add package Microsoft.EntityFrameworkCore.Sqlite
-  dotnet add package Microsoft.EntityFrameworkCore.Design
+  dotnet add <YOURPROJECT> package Microsoft.EntityFrameworkCore.Sqlite
+  dotnet add <YOURPROJECT> package Microsoft.EntityFrameworkCore.Design
   ```
 
 * Run `dotnet restore` to install the new packages.


### PR DESCRIPTION
Added '<YOURPROJECT>' to the command informing you how to add a package because the usage of the command has changed.