### PR TITLE
modify the code example language to improve display

### DIFF
--- a/entity-framework/core/modeling/value-conversions.md
+++ b/entity-framework/core/modeling/value-conversions.md
@@ -21,7 +21,7 @@ Conversions are defined using two `Func` expression trees: one from `ModelClrTyp
 ## Configuring a value converter
 
 Value conversions are defined on properties in the `OnModelCreating` of your `DbContext`. For example, consider an enum and entity type defined as:
-```Csharp
+``` csharp
 public class Rider
 {
     public int Id { get; set; }
@@ -37,7 +37,7 @@ public enum EquineBeast
 }
 ```
 Then conversions can be defined in `OnModelCreating` to store the enum values as strings (for example, "Donkey", "Mule", ...) in the database:
-```Csharp
+``` csharp
 protected override void OnModelCreating(ModelBuilder modelBuilder)
 {
     modelBuilder
@@ -54,7 +54,7 @@ protected override void OnModelCreating(ModelBuilder modelBuilder)
 ## The ValueConverter class
 
 Calling `HasConversion` as shown above will create a `ValueConverter` instance and set it on the property. The `ValueConverter` can instead be created explicitly. For example:
-```Csharp
+``` csharp
 var converter = new ValueConverter<EquineBeast, string>(
     v => v.ToString(),
     v => (EquineBeast)Enum.Parse(typeof(EquineBeast), v));
@@ -95,7 +95,7 @@ EF Core ships with a set of pre-defined `ValueConverter` classes, found in the `
 * `TimeSpanToTicksConverter` - TimeSpan to ticks
 
 Notice that `EnumToStringConverter` is included in this list. This means that there is no need to specify the conversion explicitly, as shown above. Instead, just use the built-in converter:
-```Csharp
+``` csharp
 var converter = new EnumToStringConverter<EquineBeast>();
 
 modelBuilder
@@ -108,14 +108,14 @@ Note that all the built-in converters are stateless and so a single instance can
 ## Pre-defined conversions
 
 For common conversions for which a built-in converter exists there is no need to specify the converter explicitly. Instead, just configure which provider type should be used and EF will automatically use the appropriate built-in converter. Enum to string conversions are used as an example above, but EF will actually do this automatically if the provider type is configured:
-```Csharp
+``` csharp
 modelBuilder
     .Entity<Rider>()
     .Property(e => e.Mount)
     .HasConversion<string>();
 ```
 The same thing can be achieved by explicitly specifying the column type. For example, if the entity type is defined like so:
-```Csharp
+``` csharp
 public class Rider
 {
     public int Id { get; set; }


### PR DESCRIPTION
On the docs site, using `Csharp` results in a language of `Csharp` to be displayed, where `csharp` results in `C#`

So instead of this:
![image](https://user-images.githubusercontent.com/3373249/44636254-6f16da00-a970-11e8-951e-1f4e032505ef.png)

You see this:
![image](https://user-images.githubusercontent.com/3373249/44636243-56a6bf80-a970-11e8-947b-cb6d7261161b.png)
