### PR TITLE
EF6: Fix typo in "Get Entity Framework"

### DIFF
--- a/entity-framework/ef6/fundamentals/install.md
+++ b/entity-framework/ef6/fundamentals/install.md
@@ -33,7 +33,7 @@ Install-Package EntityFramework
 
 ## Installing a specific version of EF
 
-From EF 4.1 onwards, new versions of the EF runtime have been released as the [EntityFramework NuGet Pacakge](https://www.nuget.org/packages/EntityFramework/). Any of those versions can be added to a .NET Framework-based project by running the following command in Visual Studio's [Package Manager Console](http://docs.nuget.org/docs/start-here/using-the-package-manager-console):
+From EF 4.1 onwards, new versions of the EF runtime have been released as the [EntityFramework NuGet Package](https://www.nuget.org/packages/EntityFramework/). Any of those versions can be added to a .NET Framework-based project by running the following command in Visual Studio's [Package Manager Console](http://docs.nuget.org/docs/start-here/using-the-package-manager-console):
 
 ``` powershell
 Install-Package EntityFramework -Version <number>


### PR DESCRIPTION
This fixes a typo in [the "Get Entity Framework" page](https://docs.microsoft.com/en-ca/ef/ef6/fundamentals/install) for EF6.