### PR TITLE
EF6: Fix typos in "Code First to a New Database"

### DIFF
--- a/entity-framework/ef6/modeling/code-first/workflows/new-database.md
+++ b/entity-framework/ef6/modeling/code-first/workflows/new-database.md
@@ -5,10 +5,10 @@ ms.date: "2016-10-23"
 ms.assetid: 2df6cb0a-7d8b-4e28-9d05-e2b9a90125af
 ---
 # Code First to a New Database
-This video and step-by-step walkthrough provide an introduction to Code First development targeting a new database. This scenario includes targeting a database that doesn’t exist and Code First will create, or an empty database that Code First will add new tables too. Code First allows you to define your model using C\# or VB.Net classes. Additional configuration can optionally be performed using attributes on your classes and properties or by using a fluent API.
+This video and step-by-step walkthrough provide an introduction to Code First development targeting a new database. This scenario includes targeting a database that doesn’t exist and Code First will create, or an empty database that Code First will add new tables to. Code First allows you to define your model using C\# or VB.Net classes. Additional configuration can optionally be performed using attributes on your classes and properties or by using a fluent API.
 
 ## Watch the video
-This video provides an introduction to Code First development targeting a new database. This scenario includes targeting a database that doesn’t exist and Code First will create, or an empty database that Code First will add new tables too. Code First allows you to define your model using C# or VB.Net classes. Additional configuration can optionally be performed using attributes on your classes and properties or by using a fluent API.
+This video provides an introduction to Code First development targeting a new database. This scenario includes targeting a database that doesn’t exist and Code First will create, or an empty database that Code First will add new tables to. Code First allows you to define your model using C# or VB.Net classes. Additional configuration can optionally be performed using attributes on your classes and properties or by using a fluent API.
 
 **Presented By**: [Rowan Miller](http://romiller.com/)
 


### PR DESCRIPTION
This fixes a pair of typos in [the "Code First to a New Database" page](https://docs.microsoft.com/en-ca/ef/ef6/modeling/code-first/workflows/new-database) for EF6.