### PR TITLE
remove broken breadcrumb

### DIFF
--- a/entity-framework/breadcrumb/toc.yml
+++ b/entity-framework/breadcrumb/toc.yml
@@ -43,9 +43,6 @@
       - name: Tools & Extensions
         tocHref: /ef/core/extensions/
         topicHref: /ef/core/extensions/index
-      - name: Miscellaneous
-        tocHref: /ef/core/miscellaneous/
-        topicHref: /ef/core/miscellaneous/index
     - name: Entity Framework 6
       tocHref: /ef/ef6/
       topicHref: /ef/ef6/index


### PR DESCRIPTION
That node entry doesn't have a topic associated with it.

If you click on that link on the breadcrumb from pages such as https://docs.microsoft.com/en-us/ef/core/miscellaneous/1x-2x-upgrade, you get a 404.