### PR TITLE
EF Code first sample model should use ICollection<T>

### DIFF
--- a/samples/core/GetStarted/AspNetCore/EFGetStarted.AspNetCore.NewDb/Models/Model.cs
+++ b/samples/core/GetStarted/AspNetCore/EFGetStarted.AspNetCore.NewDb/Models/Model.cs
@@ -18,7 +18,7 @@ namespace EFGetStarted.AspNetCore.NewDb.Models
         public int BlogId { get; set; }
         public string Url { get; set; }
 
-        public List<Post> Posts { get; set; }
+        public ICollection<Post> Posts { get; set; }
     }
 
     public class Post

--- a/samples/core/GetStarted/NetCore/ConsoleApp.SQLite/Model.cs
+++ b/samples/core/GetStarted/NetCore/ConsoleApp.SQLite/Model.cs
@@ -19,7 +19,7 @@ namespace ConsoleApp.SQLite
         public int BlogId { get; set; }
         public string Url { get; set; }
 
-        public List<Post> Posts { get; set; }
+        public ICollection<Post> Posts { get; set; }
     }
 
     public class Post


### PR DESCRIPTION
Modified the EF Code first sample (and thus the tutorial docs) to use ICollection<T> as the other Code first and Db first samples use as well.