### PR TITLE
C42264: Extra space at line 216

### DIFF
--- a/entity-framework/ef6/modeling/designer/advanced/edmx/msl-spec.md
+++ b/entity-framework/ef6/modeling/designer/advanced/edmx/msl-spec.md
@@ -213,7 +213,7 @@ The following example shows an **AssociationSetMapping** element in which the **
      <ScalarProperty Name="CourseID" ColumnName="CourseID" />
    </EndProperty>
  </AssociationSetMapping>
-``` 
+```
 
 ## ComplexProperty Element (MSL)
 


### PR DESCRIPTION
Hello, @divega,
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.  
Description of the source issue: Extra space is breaking the formatting on ENU site.
Please review and merge the proposed file change to fix to target versions. If you make related fix in another PR  then share your PR number so we can confirm and close this PR.
Many thanks in advance.