### PR TITLE
C42269: Extra space at line 1135

### DIFF
--- a/entity-framework/ef6/modeling/designer/advanced/edmx/csdl-spec.md
+++ b/entity-framework/ef6/modeling/designer/advanced/edmx/csdl-spec.md
@@ -1132,7 +1132,7 @@ The following example shows a **Function** element that uses one **Parameter** c
    Year(CurrentDateTime()) - Year(cast(Instructor.HireDate as DateTime))
    </DefiningExpression>
  </Function>
-``` 
+```
 
  
 


### PR DESCRIPTION
Hello, @divega,
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.  
Description of the source issue: Extra space is breaking formatting on ENU site.
Please review and merge the proposed file change to fix to target versions. If you make related fix in another PR  then share your PR number so we can confirm and close this PR.
Many thanks in advance.