### PR TITLE
Fixed typo

### DIFF
--- a/entity-framework/ef6/fundamentals/testing/mocking.md
+++ b/entity-framework/ef6/fundamentals/testing/mocking.md
@@ -206,7 +206,7 @@ namespace TestingDemo
             mockSet.As<IQueryable<Blog>>().Setup(m => m.Provider).Returns(data.Provider);
             mockSet.As<IQueryable<Blog>>().Setup(m => m.Expression).Returns(data.Expression);
             mockSet.As<IQueryable<Blog>>().Setup(m => m.ElementType).Returns(data.ElementType);
-            mockSet.As<IQueryable<Blog>>().Setup(m => m.GetEnumerator()).Returns(0 => data.GetEnumerator());
+            mockSet.As<IQueryable<Blog>>().Setup(m => m.GetEnumerator()).Returns(data.GetEnumerator());
 
             var mockContext = new Mock<BloggingContext>();
             mockContext.Setup(c => c.Blogs).Returns(mockSet.Object);


### PR DESCRIPTION
Changed `mockSet.As<IQueryable<Blog>>().Setup(m => m.GetEnumerator()).Returns(0 => data.GetEnumerator());` to `mockSet.As<IQueryable<Blog>>().Setup(m => m.GetEnumerator()).Returns(data.GetEnumerator());`

Link to issue: https://github.com/aspnet/EntityFramework.Docs/issues/1027