### PR TITLE
Add note about primary keys to Scaffold-DbContext

### DIFF
--- a/entity-framework/core/miscellaneous/cli/powershell.md
+++ b/entity-framework/core/miscellaneous/cli/powershell.md
@@ -172,7 +172,7 @@ Parameters:
 
 ## Scaffold-DbContext
 
-Generates code for a `DbContext` and entity types for a database.
+Generates code for a `DbContext` and entity types for a database. In order for `Scaffold-DbContext` to generate the model, the database table must have a primary key identified. 
 
 Parameters:
 


### PR DESCRIPTION
Scaffold-DbContext will not generate a data model if the table does not have a primary key assigned.