### PR TITLE
Fixing UWP tutorial steps

### DIFF
--- a/entity-framework/core/get-started/uwp/getting-started.md
+++ b/entity-framework/core/get-started/uwp/getting-started.md
@@ -1,14 +1,14 @@
 ---
 title: Getting Started on UWP - New Database - EF Core
 author: rowanmiller
-ms.date: 10/11/2018
+ms.date: 10/13/2018
 ms.assetid: a0ae2f21-1eef-43c6-83ad-92275f9c0727
 uid: core/get-started/uwp/getting-started
 ---
 
 # Getting Started with EF Core on Universal Windows Platform (UWP) with a New Database
 
-In this tutorial, you build a Universal Windows Platform (UWP) application that performs basic data access against a local SQLite database using Entity Framework Core. You will use EF Core migrations to create a new the database based on the application's data.  
+In this tutorial, you build a Universal Windows Platform (UWP) application that performs basic data access against a local SQLite database using Entity Framework Core.   
 
 [View this article's sample on GitHub](https://github.com/aspnet/EntityFramework.Docs/tree/master/samples/core/GetStarted/UWP).
 
@@ -20,12 +20,12 @@ In this tutorial, you build a Universal Windows Platform (UWP) application that 
 
 * [.NET Core 2.1 SDK or later](https://www.microsoft.com/net/core) or later.
 
-## Create a library project for the model
-
 > [!IMPORTANT]
-> Due to limitations, the EF Core migration tools don't work directly with UWP projects.
-> The data model needs to be placed in a separate library project.
-> The **Package Manager Console** (PMC) migrations commands can then execute against a separate .NET Core console application that references that library project.
+> Later in this tutorial you will use Entity Framework Core migrations commands to create and update the schema of the database.
+> The EF Core migration commands don't work directly with UWP projects.
+> For this reason, you will place the application's data model in a shared library project, and you will then create a separate .NET Core console application to execute the commands.
+
+## Create a library project for the data model
 
 * Open Visual Studio
 
@@ -41,7 +41,7 @@ In this tutorial, you build a Universal Windows Platform (UWP) application that 
 
 * Click **OK**.
 
-## Install Entity Framework Core in the model project
+## Install Entity Framework Core runtime in the data model project
 
 To use EF Core, install the package for the database provider(s) you want to target. This tutorial uses SQLite. For a list of available providers see [Database Providers](../../providers/index.md).
 
@@ -49,7 +49,7 @@ To use EF Core, install the package for the database provider(s) you want to tar
 
 * Run `Install-Package Microsoft.EntityFrameworkCore.Sqlite`
 
-## Create the model
+## Create the data model
 
 Now it's time to define a context and entity classes that make up the model.
 
@@ -59,21 +59,7 @@ Now it's time to define a context and entity classes that make up the model.
 
   [!code-csharp[Main](../../../../samples/core/GetStarted/UWP/Blogging.Model/Model.cs)]
 
-## Create a new UWP project
-
-* In **Solution Explorer**, right-click the solution, and then choose **Add > New Project**.
-
-* From the left menu select **Installed > Visual C# > Windows Universal**.
-
-* Select the **Blank App (Universal Windows)** project template.
-
-* Name the project *Blogging.UWP*, and click **OK**
-
-* Set the target and minimum versions to at least **Windows 10 Fall Creators Update (10.0; build 16299.0)**.
-
 ## Create a new console project to run migrations commands
-
-Migrations tools require a non-UWP startup project, so create that first.
 
 * In **Solution Explorer**, right-click the solution, and then choose **Add > New Project**.
 
@@ -85,25 +71,37 @@ Migrations tools require a non-UWP startup project, so create that first.
 
 * Add a project reference from the *Blogging.Migrations.Startup* project to the *Blogging.Model* project.
 
+## Install Entity Framework Core tools in the migrations startup project
+
+To enable the EF Core migration commands in the Package Manager Console (PMC), install the EF Core tools package.
+
 * **Tools > NuGet Package Manager > Package Manager Console**
 
-* Select the *Blogging.Model* project as the **Default project**.
-
-* In **Solution Explorer**, set the *Blogging.Migrations.Startup* project as the startup project.
-
-You will be using EF Core migration commands to maintain the database. So install the tools package as well.
-
-* Run `Install-Package Microsoft.EntityFrameworkCore.Tools`
+* Run `Install-Package Microsoft.EntityFrameworkCore.Tools -ProjectName Blogging.Migrations.Startup`
 
 ## Create the initial migration
 
-Now that you have a model, set up the app to create a database the first time it runs. In this section, you create the initial migration. In the following section, you add code that applies this migration when the app starts.
+ Create the initial migration.
 
-* Run `Add-Migration InitialCreate`.
+* Run `Add-Migration InitialCreate -StartupProject Blogging.Migrations.Startup`
 
-  This command scaffolds a migration that creates the initial set of tables for your model.
+This command scaffolds a migration that creates the initial set of tables for your model.
 
-## Create the database on app startup
+## Create a new UWP project
+
+* In **Solution Explorer**, right-click the solution, and then choose **Add > New Project**.
+
+* From the left menu select **Installed > Visual C# > Windows Universal**.
+
+* Select the **Blank App (Universal Windows)** project template.
+
+* Name the project *Blogging.UWP*, and click **OK**
+
+> [!IMPORTANT]
+> Set the target and minimum versions to at least **Windows 10 Fall Creators Update (10.0; build 16299.0)**.
+> Previous  versions of Windows 10 do not support .NET Standard 2.0, which is required by Entity Framework Core.
+
+## Create the database on application startup
 
 Since you want the database to be created on the device that the app runs on, add code to apply any pending migrations to the local database on application startup. The first time that the app runs, this will take care of creating the local database.
 

--- a/entity-framework/core/get-started/uwp/getting-started.md
+++ b/entity-framework/core/get-started/uwp/getting-started.md
@@ -8,7 +8,7 @@ uid: core/get-started/uwp/getting-started
 
 # Getting Started with EF Core on Universal Windows Platform (UWP) with a New Database
 
-In this tutorial, you build a Universal Windows Platform (UWP) application that performs basic data access against a local SQLite database using Entity Framework Core.   
+In this tutorial, you build a Universal Windows Platform (UWP) application that performs basic data access against a local SQLite database using Entity Framework Core.
 
 [View this article's sample on GitHub](https://github.com/aspnet/EntityFramework.Docs/tree/master/samples/core/GetStarted/UWP).
 
@@ -25,7 +25,7 @@ In this tutorial, you build a Universal Windows Platform (UWP) application that 
 > These commands don't work directly with UWP projects.
 > For this reason, the application's data model is placed in a shared library project, and a separate .NET Core console application is used to run the commands.
 
-## Create a library project for the data model
+## Create a library project to hold the data model
 
 * Open Visual Studio
 
@@ -75,7 +75,7 @@ Now it's time to define a context and entity classes that make up the model.
 
 ## Install Entity Framework Core tools in the migrations startup project
 
-To enable the EF Core migration commands in the Package Manager Console (PMC), install the EF Core tools package.
+To enable the EF Core migration commands in the Package Manager Console (PMC), install the EF Core tools package in the console application.
 
 * **Tools > NuGet Package Manager > Package Manager Console**
 
@@ -103,7 +103,7 @@ This command scaffolds a migration that creates the initial set of database tabl
 > Set the target and minimum versions to at least **Windows 10 Fall Creators Update (10.0; build 16299.0)**.
 > Previous  versions of Windows 10 do not support .NET Standard 2.0, which is required by Entity Framework Core.
 
-## Create the database on application startup
+## Add code to create the database on application startup
 
 Since you want the database to be created on the device that the app runs on, add code to apply any pending migrations to the local database on application startup. The first time that the app runs, this will take care of creating the local database.
 

--- a/entity-framework/core/get-started/uwp/getting-started.md
+++ b/entity-framework/core/get-started/uwp/getting-started.md
@@ -97,6 +97,10 @@ Now you can create your initial migration.
 
 * In **Solution Explorer**, set the *Blogging.Migrations.Startup* project as the startup project.
 
+* Run `Install-Package Microsoft.EntityFrameworkCore.Design`
+
+This package is required by the toolkit Microsoft.EntityFrameworkCore.Tools.
+
 * Run `Add-Migration InitialCreate`.
 
   This command scaffolds a migration that creates the initial set of tables for your model.

--- a/entity-framework/core/get-started/uwp/getting-started.md
+++ b/entity-framework/core/get-started/uwp/getting-started.md
@@ -1,14 +1,14 @@
 ---
 title: Getting Started on UWP - New Database - EF Core
 author: rowanmiller
-ms.date: 08/08/2018
+ms.date: 10/11/2018
 ms.assetid: a0ae2f21-1eef-43c6-83ad-92275f9c0727
 uid: core/get-started/uwp/getting-started
 ---
 
 # Getting Started with EF Core on Universal Windows Platform (UWP) with a New Database
 
-In this tutorial, you build a Universal Windows Platform (UWP) application that performs basic data access against a local SQLite database using Entity Framework Core.
+In this tutorial, you build a Universal Windows Platform (UWP) application that performs basic data access against a local SQLite database using Entity Framework Core. You will use EF Core migrations to create a new the database based on the application's data.  
 
 [View this article's sample on GitHub](https://github.com/aspnet/EntityFramework.Docs/tree/master/samples/core/GetStarted/UWP).
 
@@ -20,10 +20,12 @@ In this tutorial, you build a Universal Windows Platform (UWP) application that 
 
 * [.NET Core 2.1 SDK or later](https://www.microsoft.com/net/core) or later.
 
-## Create a model project
+## Create a library project for the model
 
 > [!IMPORTANT]
-> Due to limitations in the way .NET Core tools interact with UWP projects the model needs to be placed in a non-UWP project to be able to run migrations commands in the **Package Manager Console** (PMC)
+> Due to limitations, the EF Core migration tools don't work directly with UWP projects.
+> The data model needs to be placed in a separate library project.
+> The **Package Manager Console** (PMC) migrations commands can then execute against a separate .NET Core console application that references that library project.
 
 * Open Visual Studio
 
@@ -39,17 +41,13 @@ In this tutorial, you build a Universal Windows Platform (UWP) application that 
 
 * Click **OK**.
 
-## Install Entity Framework Core
+## Install Entity Framework Core in the model project
 
 To use EF Core, install the package for the database provider(s) you want to target. This tutorial uses SQLite. For a list of available providers see [Database Providers](../../providers/index.md).
 
 * **Tools > NuGet Package Manager > Package Manager Console**.
 
 * Run `Install-Package Microsoft.EntityFrameworkCore.Sqlite`
-
-Later in this tutorial you will be using some Entity Framework Core tools to maintain the database. So install the tools package as well.
-
-* Run `Install-Package Microsoft.EntityFrameworkCore.Tools`
 
 ## Create the model
 
@@ -73,9 +71,7 @@ Now it's time to define a context and entity classes that make up the model.
 
 * Set the target and minimum versions to at least **Windows 10 Fall Creators Update (10.0; build 16299.0)**.
 
-## Create the initial migration
-
-Now that you have a model, set up the app to create a database the first time it runs. In this section, you create the initial migration. In the following section, you add code that applies this migration when the app starts.
+## Create a new console project to run migrations commands
 
 Migrations tools require a non-UWP startup project, so create that first.
 
@@ -89,17 +85,19 @@ Migrations tools require a non-UWP startup project, so create that first.
 
 * Add a project reference from the *Blogging.Migrations.Startup* project to the *Blogging.Model* project.
 
-Now you can create your initial migration.
-
 * **Tools > NuGet Package Manager > Package Manager Console**
 
 * Select the *Blogging.Model* project as the **Default project**.
 
 * In **Solution Explorer**, set the *Blogging.Migrations.Startup* project as the startup project.
 
-* Run `Install-Package Microsoft.EntityFrameworkCore.Design`
+You will be using EF Core migration commands to maintain the database. So install the tools package as well.
 
-  This package is required by the toolkit Microsoft.EntityFrameworkCore.Tools.
+* Run `Install-Package Microsoft.EntityFrameworkCore.Tools`
+
+## Create the initial migration
+
+Now that you have a model, set up the app to create a database the first time it runs. In this section, you create the initial migration. In the following section, you add code that applies this migration when the app starts.
 
 * Run `Add-Migration InitialCreate`.
 

--- a/entity-framework/core/get-started/uwp/getting-started.md
+++ b/entity-framework/core/get-started/uwp/getting-started.md
@@ -21,9 +21,9 @@ In this tutorial, you build a Universal Windows Platform (UWP) application that 
 * [.NET Core 2.1 SDK or later](https://www.microsoft.com/net/core) or later.
 
 > [!IMPORTANT]
-> Later in this tutorial you will use Entity Framework Core migrations commands to create and update the schema of the database.
-> The EF Core migration commands don't work directly with UWP projects.
-> For this reason, you will place the application's data model in a shared library project, and you will then create a separate .NET Core console application to execute the commands.
+> This tutorial uses Entity Framework Core migrations commands to create and update the schema of the database.
+> These commands don't work directly with UWP projects.
+> For this reason, the application's data model is placed in a shared library project, and a separate .NET Core console application is used to run the commands.
 
 ## Create a library project for the data model
 
@@ -46,6 +46,8 @@ In this tutorial, you build a Universal Windows Platform (UWP) application that 
 To use EF Core, install the package for the database provider(s) you want to target. This tutorial uses SQLite. For a list of available providers see [Database Providers](../../providers/index.md).
 
 * **Tools > NuGet Package Manager > Package Manager Console**.
+
+* Make sure that the library project *Blogging.Model* is selected the **Default Project** in the Package Manager Console.
 
 * Run `Install-Package Microsoft.EntityFrameworkCore.Sqlite`
 
@@ -81,7 +83,7 @@ To enable the EF Core migration commands in the Package Manager Console (PMC), i
 
 ## Create the initial migration
 
- Create the initial migration. You indicate the command to use the console application as the startup project.
+ Create the initial migration, specifying the console application as the startup project.
 
 * Run `Add-Migration InitialCreate -StartupProject Blogging.Migrations.Startup`
 

--- a/entity-framework/core/get-started/uwp/getting-started.md
+++ b/entity-framework/core/get-started/uwp/getting-started.md
@@ -99,7 +99,7 @@ Now you can create your initial migration.
 
 * Run `Install-Package Microsoft.EntityFrameworkCore.Design`
 
-This package is required by the toolkit Microsoft.EntityFrameworkCore.Tools.
+  This package is required by the toolkit Microsoft.EntityFrameworkCore.Tools.
 
 * Run `Add-Migration InitialCreate`.
 

--- a/entity-framework/core/get-started/uwp/getting-started.md
+++ b/entity-framework/core/get-started/uwp/getting-started.md
@@ -21,7 +21,7 @@ In this tutorial, you build a Universal Windows Platform (UWP) application that 
 * [.NET Core 2.1 SDK or later](https://www.microsoft.com/net/core) or later.
 
 > [!IMPORTANT]
-> This tutorial uses Entity Framework Core migrations commands to create and update the schema of the database.
+> This tutorial uses Entity Framework Core [migrations](xref:core/managing-schemas/migrations/index) commands to create and update the schema of the database.
 > These commands don't work directly with UWP projects.
 > For this reason, the application's data model is placed in a shared library project, and a separate .NET Core console application is used to run the commands.
 
@@ -47,13 +47,13 @@ To use EF Core, install the package for the database provider(s) you want to tar
 
 * **Tools > NuGet Package Manager > Package Manager Console**.
 
-* Make sure that the library project *Blogging.Model* is selected the **Default Project** in the Package Manager Console.
+* Make sure that the library project *Blogging.Model* is selected as the **Default Project** in the Package Manager Console.
 
 * Run `Install-Package Microsoft.EntityFrameworkCore.Sqlite`
 
 ## Create the data model
 
-Now it's time to define a context and entity classes that make up the model.
+Now it's time to define the *DbContext* and entity classes that make up the model.
 
 * Delete *Class1.cs*.
 
@@ -75,7 +75,7 @@ Now it's time to define a context and entity classes that make up the model.
 
 ## Install Entity Framework Core tools in the migrations startup project
 
-To enable the EF Core migration commands in the Package Manager Console (PMC), install the EF Core tools package in the console application.
+To enable the EF Core migration commands in the Package Manager Console, install the EF Core tools package in the console application.
 
 * **Tools > NuGet Package Manager > Package Manager Console**
 

--- a/entity-framework/core/get-started/uwp/getting-started.md
+++ b/entity-framework/core/get-started/uwp/getting-started.md
@@ -81,13 +81,13 @@ To enable the EF Core migration commands in the Package Manager Console (PMC), i
 
 ## Create the initial migration
 
- Create the initial migration.
+ Create the initial migration. You indicate the command to use the console application as the startup project.
 
 * Run `Add-Migration InitialCreate -StartupProject Blogging.Migrations.Startup`
 
-This command scaffolds a migration that creates the initial set of tables for your model.
+This command scaffolds a migration that creates the initial set of database tables for your data model.
 
-## Create a new UWP project
+## Create the UWP project
 
 * In **Solution Explorer**, right-click the solution, and then choose **Add > New Project**.
 
@@ -116,11 +116,11 @@ Since you want the database to be created on the device that the app runs on, ad
 > [!TIP]  
 > If you change your model, use the `Add-Migration` command to scaffold a new migration to apply the corresponding changes to the database. Any pending migrations will be applied to the local database on each device when the application starts.
 >
->EF uses a `__EFMigrationsHistory` table in the database to keep track of which migrations have already been applied to the database.
+>EF Core uses a `__EFMigrationsHistory` table in the database to keep track of which migrations have already been applied to the database.
 
-## Use the model
+## Use the data model
 
-You can now use the model to perform data access.
+You can now use EF Core to perform data access.
 
 * Open *MainPage.xaml*.
 


### PR DESCRIPTION
This update corrects what project ends up contiaing the tools package and changes the migrations commands to not require that the console application is selected as startup project. 

I have made a few changes that I think make it easier to complete the tutorial without making mistakes. 

# Original content
Hello, @rowanmiller,
This proposed file change comes from https://github.com/aspnet/EntityFramework.Docs.es-es/pull/4 .
Could you review this contribution and help to merge if agreed?
Many thanks in advance.