### PR TITLE
Fix wrong double quote character

### DIFF
--- a/entity-framework/ef6/modeling/code-first/fluent/types-and-properties.md
+++ b/entity-framework/ef6/modeling/code-first/fluent/types-and-properties.md
@@ -18,7 +18,7 @@ The code first fluent API is most commonly accessed by overriding the [OnModelCr
 Starting with EF6 you can use the HasDefaultSchema method on DbModelBuilder to specify the database schema to use for all tables, stored procedures, etc. This default setting will be overridden for any objects that you explicitly configure a different schema for.  
 
 ``` csharp
-modelBuilder.HasDefaultSchema(“sales”);
+modelBuilder.HasDefaultSchema("sales");
 ```  
 
 ### Custom Conventions (EF6 onwards)  


### PR DESCRIPTION
The character `“` was used instead of `"` in a code exemple. It was then not working properly when copy-pasted.