### PR TITLE
Updated API reference links for EF6

### DIFF
--- a/entity-framework/index.md
+++ b/entity-framework/index.md
@@ -271,7 +271,7 @@ uid: index
                                 </a>
                             </li>
                             <li>
-                                <a href="https://msdn.microsoft.com/library/dn223258(v=vs.113).aspx">
+                                <a href="https://docs.microsoft.com/dotnet/api/?view=entity-framework-6.2.0">
                                     <div class="cardSize">
                                         <div class="cardPadding">
                                             <div class="card">

--- a/entity-framework/toc.md
+++ b/entity-framework/toc.md
@@ -285,4 +285,4 @@
 ###### [Korean](ef6/resources/licenses/ef6/kor.md)
 ###### [Russian](ef6/resources/licenses/ef6/rus.md)
 
-### [⤤ EF6 API Reference](https://msdn.microsoft.com/library/dn223258.aspx)
+### [⤤ EF6 API Reference](https://docs.microsoft.com/dotnet/api/?view=entity-framework-6.2.0)


### PR DESCRIPTION
New location is https://docs.microsoft.com/dotnet/api/?view=entity-framework-6.2.0.