### PR TITLE
Revert "Example Code Screenshot mismatch"

### DIFF
--- a/entity-framework/ef6/fundamentals/async.md
+++ b/entity-framework/ef6/fundamentals/async.md
@@ -90,6 +90,7 @@ Now that we have an EF model, let's write some code that uses it to perform some
             {
                 PerformDatabaseOperations();
 
+                Console.WriteLine();
                 Console.WriteLine("Quote of the day");
                 Console.WriteLine(" Don't worry about the world coming to an end today... ");
                 Console.WriteLine(" It's already tomorrow in Australia.");
@@ -108,18 +109,16 @@ Now that we have an EF model, let's write some code that uses it to perform some
                     {
                         Name = "Test Blog #" + (db.Blogs.Count() + 1)
                     });
-                    Console.WriteLine("Calling SaveChanges.");
                     db.SaveChanges();
-                    Console.WriteLine("SaveChanges completed.");
 
                     // Query for all blogs ordered by name
-                    Console.WriteLine("Executing query.");
                     var blogs = (from b in db.Blogs
                                 orderby b.Name
                                 select b).ToList();
 
                     // Write all blogs out to Console
-                    Console.WriteLine("Query completed with following results:");
+                    Console.WriteLine();
+                    Console.WriteLine("All blogs:");
                     foreach (var blog in blogs)
                     {
                         Console.WriteLine(" " + blog.Name);


### PR DESCRIPTION
I am going to revert aspnet/EntityFramework.Docs#1172 to take https://github.com/aspnet/EntityFramework.Docs/pull/1170 first, which contains mostly of the same fix but was posted once day before. 