### PR TITLE
Update link to the official Npgsql provider

### DIFF
--- a/entity-framework/ef6/fundamentals/providers/index.md
+++ b/entity-framework/ef6/fundamentals/providers/index.md
@@ -32,7 +32,7 @@ Providers we are aware of that have been rebuilt for EF6 include:
 *   **MySQL**
     *   [MySQL Connector/Net](http://dev.mysql.com/downloads/connector/net/)
 *   **PostgreSQL**
-    *   Npgsql is available as a [NuGet package](http://www.nuget.org/packages/Npgsql.EF6/)
+    *   Npgsql is available as a [NuGet package](https://www.nuget.org/packages/EntityFramework6.Npgsql/)
 *   **Oracle**
     *   ODP.NET is available as a [NuGet package](https://www.nuget.org/packages/Oracle.ManagedDataAccess.EntityFramework/)
 


### PR DESCRIPTION
Npgsql.EF6 is an old, pre-release package, the current official NuGet package is EntityFramework6.Npgsql