### PR TITLE
Update MySQL Connector/NET link

### DIFF
--- a/entity-framework/ef6/fundamentals/providers/index.md
+++ b/entity-framework/ef6/fundamentals/providers/index.md
@@ -30,7 +30,7 @@ Providers we are aware of that have been rebuilt for EF6 include:
 *   **Visual Fox Pro provider**
     *   Available as a [NuGet package](https://www.nuget.org/packages/VFPEntityFrameworkProvider2/)
 *   **MySQL**
-    *   [MySQL Connector/Net](http://dev.mysql.com/downloads/connector/net/)
+    *   [MySQL Connector/NET for Entity Framework](https://dev.mysql.com/doc/connector-net/en/connector-net-entityframework60.html)
 *   **PostgreSQL**
     *   Npgsql is available as a [NuGet package](http://www.nuget.org/packages/Npgsql.EF6/)
 *   **Oracle**


### PR DESCRIPTION
The new link provides information on how to install and configure MySQL Connector/NET for EF6.