### PR TITLE
Fix grammar for including multiple related entities

### DIFF
--- a/entity-framework/core/querying/related-data.md
+++ b/entity-framework/core/querying/related-data.md
@@ -47,7 +47,7 @@ You can combine all of this to include related data from multiple levels and mul
 
 [!code-csharp[Main](../../../samples/core/Querying/Querying/RelatedData/Sample.cs#IncludeTree)]
 
-You may want to include multiple related entities for one of the entities that is being included. For example, when querying `Blog`s, you include `Posts` and then want to include both the `Author` and `Tags` of the `Posts`. To do this, you need to specify each include path starting at the root. For example, `Blog -> Posts -> Author` and `Blog -> Posts -> Tags`. This does not mean you will get redundant joins, in most cases EF will consolidate the joins when generating SQL.
+You may want to include multiple related entities for one of the entities that is being included. For example, when querying `Blog`s, you include `Posts` and then want to include both the `Author` and `Tags` of the `Posts`. To do this, you need to specify each include path starting at the root. For example, `Blog -> Posts -> Author` and `Blog -> Posts -> Tags`. This does not mean you will get redundant joins; in most cases, EF will consolidate the joins when generating SQL.
 
 [!code-csharp[Main](../../../samples/core/Querying/Querying/RelatedData/Sample.cs#MultipleLeafIncludes)]
 


### PR DESCRIPTION
Changed

```
This does not mean you will get redundant joins, in most cases EF will consolidate the joins when generating SQL.
```

to

```
This does not mean you will get redundant joins; in most cases, EF will consolidate the joins when generating SQL.
```

for better clarity.