### PR TITLE
Removed an extra square bracket

### DIFF
--- a/entity-framework/core/get-started/install/index.md
+++ b/entity-framework/core/get-started/install/index.md
@@ -25,7 +25,7 @@ To add EF Core to an application, install the NuGet package for the database pro
 
 If you're building an ASP.NET Core application, you don't need to install the in-memory and SQL Server providers. Those providers are included in current versions of ASP.NET Core, alongside the EF Core runtime.  
 
-To install or update NuGet packages, you can use the [.NET Core command-line interface (CLI), the Visual Studio Package Manager Dialog, or the Visual Studio Package Manager Console.
+To install or update NuGet packages, you can use the .NET Core command-line interface (CLI), the Visual Studio Package Manager Dialog, or the Visual Studio Package Manager Console.
 
 ### .NET Core CLI
 


### PR DESCRIPTION
This may have been a hyperlink in the past (to something like [this](https://docs.microsoft.com/en-us/dotnet/core/tools/?tabs=netcore2x)).

I've just removed the bracket, but can add in the hyperlink if desired.