### PR TITLE
EF Core 3.0 new features and breaking changes

### DIFF
--- a/entity-framework/core/what-is-new/ef-core-3.0/breaking-changes.md
+++ b/entity-framework/core/what-is-new/ef-core-3.0/breaking-changes.md
@@ -1,0 +1,14 @@
+---
+title: Breaking changes in EF Core 3.0 - EF Core
+author: divega
+ms.date: 02/19/2019
+ms.assetid: EE2878C9-71F9-4FA5-9BC4-60517C7C9830
+uid: core/what-is-new/ef-core-3.0/breaking-changes
+---
+
+# Breaking changes included in EF Core 3.0 (in preview)
+
+> [!IMPORTANT]
+> Please note that the feature sets and schedules of future releases are always subject to change, and although we will try to keep this page up to date, it may not reflect our latest plans at all times.
+
+(TBD)

--- a/entity-framework/core/what-is-new/ef-core-3.0/features.md
+++ b/entity-framework/core/what-is-new/ef-core-3.0/features.md
@@ -1,0 +1,49 @@
+---
+title: New features in EF Core 3.0 - EF Core
+author: divega
+ms.date: 02/19/2019
+ms.assetid: 2EBE2CCC-E52D-483F-834C-8877F5EB0C0C
+uid: core/what-is-new/ef-core-3.0/features
+---
+
+# New features included in EF Core 3.0 (in preview)
+
+> [!IMPORTANT]
+> Please note that the feature sets and schedules of future releases are always subject to change, and although we will try to keep this page up to date, it may not reflect our latest plans at all times.
+
+## LINQ improvements ([#12795](https://github.com/aspnet/EntityFrameworkCore/issues/12795))
+
+LINQ enables you to write database queries without leaving your language of choice, taking advantage of rich type information to get IntelliSense and compile-time type checking.
+But LINQ also enables you to write an unlimited number of complicated queries, and that has always been a huge challenge for LINQ providers.
+In the first few versions of EF Core, we solved that in part by figuring out what portions of a query could be translated to SQL, and then by allowing the rest of the query to execute in memory on the client.
+This client-side execution can be desirable in some situations, but in many other cases it can result in inefficient queries that may not be identified until an application is deployed to production.
+In EF Core 3.0, we are planning to make profound changes to how our LINQ implementation works, and how we test it.
+The goals are to make it more robust (for example, to avoid breaking queries in patch releases), to be able to translate more expressions correctly into SQL, to generate efficient queries in more cases, and to prevent inefficient queries from going undetected.
+
+## Cosmos DB support ([#8443](https://github.com/aspnet/EntityFrameworkCore/issues/8443))
+
+We're working on a Cosmos DB provider for EF Core, to enable developers familiar with the EF programing model to easily target Azure Cosmos DB as an application database.
+The goal is to make some of the advantages of Cosmos DB, like global distribution, “always on” availability, elastic scalability, and low latency, even more accessible to .NET developers.
+The provider will enable most EF Core features, like automatic change tracking, LINQ, and value conversions, against the SQL API in Cosmos DB. We started this effort before EF Core 2.2, and [we have made some preview versions of the provider available](https://blogs.msdn.microsoft.com/dotnet/2018/10/17/announcing-entity-framework-core-2-2-preview-3/).
+The new plan is to continue developing the provider alongside EF Core 3.0.   
+
+## C# 8.0 support ([#12047](https://github.com/aspnet/EntityFrameworkCore/issues/12047))
+
+We want our customers to take advantage of some of the [new features coming in C# 8.0](https://blogs.msdn.microsoft.com/dotnet/2018/11/12/building-c-8-0/) like async streams (including await for each) and nullable reference types while using EF Core.
+
+## Reverse engineering database views into query types ([#1679](https://github.com/aspnet/EntityFrameworkCore/issues/1679))
+
+In EF Core 2.1, we added support for query types, which can represent data that can be read from the database, but cannot be updated.
+Query types are a great fit for mapping database views, so in EF Core 3.0, we would like to automate the creation of query types for database views.
+
+## Property bag entities ([#13610](https://github.com/aspnet/EntityFrameworkCore/issues/13610) and [#9914](https://github.com/aspnet/EntityFrameworkCore/issues/9914))
+
+This feature is about enabling entities that store data in indexed properties instead of regular properties, and also about being able to use instances of the same .NET class (potentially something as simple as a `Dictionary<string, object>`) to represent different entity types in the same EF Core model.
+This feature is a stepping stone to support many-to-many relationships without a join entity, which is one of the most requested improvements for EF Core.
+
+## EF 6.3 on .NET Core ([EF6 #271](https://github.com/aspnet/EntityFramework6/issues/271))
+
+We understand that many existing applications use previous versions of EF, and that porting them to EF Core only to take advantage of .NET Core can sometimes require a significant effort.
+For that reason, we will be adapting the next version of EF 6 to run on .NET Core 3.0.
+We are doing this to facilitate porting existing applications with minimal changes.
+There are going to be some limitations (for example, it will require new providers, spatial support with SQL Server won't be enabled), and there are no new features planned for EF 6.

--- a/entity-framework/core/what-is-new/ef-core-3.0/index.md
+++ b/entity-framework/core/what-is-new/ef-core-3.0/index.md
@@ -1,0 +1,18 @@
+---
+title: What is new in EF Core 3.0 - EF Core
+author: divega
+ms.date: 02/19/2019
+ms.assetid: 8C90C074-0A5B-4567-AF79-799B7BC78062
+uid: core/what-is-new/ef-core-3.0/index
+---
+
+# What is new in EF Core 3.0 (in preview)
+
+> [!IMPORTANT]
+> Please note that the feature sets and schedules of future releases are always subject to change, and although we will try to keep this page up to date, it may not reflect our latest plans at all times.
+
+EF Core 3.0 is currently under development and available in preview. EF Core 3.0 will bring a set of [new features](xref:core/what-is-new/ef-core-3.0/features) and also [breaking changes](xref:core/what-is-new/ef-core-3.0/breaking-changes) you should be aware of when upgrading.
+
+Early [preview packages published to the NuGet Gallery](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore/) only contain [bug fixes, minor improvements, and changes we made in preparation for the 3.0 work](https://github.com/aspnet/EntityFrameworkCore/issues?q=is%3Aissue+milestone%3A3.0.0+is%3Aclosed+label%3Aclosed-fixed).
+
+Successive preview releases will contain more of the planned features and breaking changes. In the meantime, you can use [this query in our issue tracker](https://github.com/aspnet/EntityFrameworkCore/issues?q=is%3Aopen+is%3Aissue+milestone%3A3.0.0+sort%3Areactions-%2B1-desc) to see work items tentatively assigned to 3.0.

--- a/entity-framework/core/what-is-new/index.md
+++ b/entity-framework/core/what-is-new/index.md
@@ -8,11 +8,11 @@ uid: core/what-is-new/index
 
 # What is new in EF core
 
-You can use the links below to learn about new features in each release:
-
 ## Future releases
 
-- [EF Core Roadmap](xref:core/what-is-new/roadmap)
+EF Core 3.0 is currently available in preview. EF Core 3.0 brings a set of [new features](xref:core/what-is-new/ef-core-3.0/features) and also [breaking changes](xref:core/what-is-new/ef-core-3.0/breaking-changes) you should be aware of when upgrading.
+
+For more details on how we plan future releases like 3.0 and beyond, see the [EF Core Roadmap](xref:core/what-is-new/roadmap).
 
 ## Recent releases
 

--- a/entity-framework/core/what-is-new/roadmap.md
+++ b/entity-framework/core/what-is-new/roadmap.md
@@ -14,7 +14,7 @@ uid: core/what-is-new/roadmap
 ### EF Core 3.0
 
 With EF Core 2.2 out the door, our main focus is now EF Core 3.0, which will be aligned with the .NET Core 3.0 and ASP.NET 3.0 releases.
-See [What's new in EF Core 3.0](xref://core/what-is-new/ef-core-3.0/index) for release details, planned [new features](xref://core/what-is-new/ef-core-3.0/features), and intentional [breaking changes](xref://core/what-is-new/ef-core-3.0/breaking-changes) included in EF Core 3.0.   
+See [What's new in EF Core 3.0](xref:core/what-is-new/ef-core-3.0/index) for release details, planned [new features](xref:core/what-is-new/ef-core-3.0/features), and intentional [breaking changes](xref:core/what-is-new/ef-core-3.0/breaking-changes) included in EF Core 3.0.
 
 ## Schedule
 

--- a/entity-framework/core/what-is-new/roadmap.md
+++ b/entity-framework/core/what-is-new/roadmap.md
@@ -14,38 +14,7 @@ uid: core/what-is-new/roadmap
 ### EF Core 3.0
 
 With EF Core 2.2 out the door, our main focus is now EF Core 3.0, which will be aligned with the .NET Core 3.0 and ASP.NET 3.0 releases.
-
-We haven't completed any new features yet, so the [EF Core 3.0 Preview 1 packages published to the NuGet Gallery](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore/3.0.0-preview.18572.1) on December 2018 only contain [bug fixes, minor improvements, and changes we made in preparation for the 3.0 work](https://github.com/aspnet/EntityFrameworkCore/issues?q=is%3Aissue+milestone%3A3.0.0+is%3Aclosed+label%3Aclosed-fixed).
-
-In fact, we still need to refine our [release planning](#release-planning-process) for 3.0, to make sure we have the right set of features that can be completed in the allotted time.
-We will share more information as we get more clarity, but here are some high-level themes and features we intend to work on:
-
-- **LINQ improvements ([#12795](https://github.com/aspnet/EntityFrameworkCore/issues/12795))**: LINQ enables you to write database queries without leaving your language of choice, taking advantage of rich type information to get IntelliSense and compile-time type checking.
-  But LINQ also enables you to write an unlimited number of complicated queries, and that has always been a huge challenge for LINQ providers.
-  In the first few versions of EF Core, we solved that in part by figuring out what portions of a query could be translated to SQL, and then by allowing the rest of the query to execute in memory on the client.
-  This client-side execution can be desirable in some situations, but in many other cases it can result in inefficient queries that may not be identified until an application is deployed to production.
-  In EF Core 3.0, we are planning to make profound changes to how our LINQ implementation works, and how we test it.
-  The goals are to make it more robust (for example, to avoid breaking queries in patch releases), to be able to translate more expressions correctly into SQL, to generate efficient queries in more cases, and to prevent inefficient queries from going undetected.
-
-- **Cosmos DB support ([#8443](https://github.com/aspnet/EntityFrameworkCore/issues/8443))**: We're working on a Cosmos DB provider for EF Core, to enable developers familiar with the EF programing model to easily target Azure Cosmos DB as an application database.
-  The goal is to make some of the advantages of Cosmos DB, like global distribution, “always on” availability, elastic scalability, and low latency, even more accessible to .NET developers.
-  The provider will enable most EF Core features, like automatic change tracking, LINQ, and value conversions, against the SQL API in Cosmos DB. We started this effort before EF Core 2.2, and [we have made some preview versions of the provider available](https://blogs.msdn.microsoft.com/dotnet/2018/10/17/announcing-entity-framework-core-2-2-preview-3/).
-  The new plan is to continue developing the provider alongside EF Core 3.0.   
-
-- **C# 8.0 support ([#12047](https://github.com/aspnet/EntityFrameworkCore/issues/12047))**: We want our customers to take advantage of some of the [new features coming in C# 8.0](https://blogs.msdn.microsoft.com/dotnet/2018/11/12/building-c-8-0/) like async streams (including await for each) and nullable reference types while using EF Core.
-
-- **Reverse engineering database views into query types ([#1679](https://github.com/aspnet/EntityFrameworkCore/issues/1679))**: In EF Core 2.1, we added support for query types, which can represent data that can be read from the database, but cannot be updated.
-  Query types are a great fit for mapping database views, so in EF Core 3.0, we would like to automate the creation of query types for database views.
-
-- **Property bag entities ([#13610](https://github.com/aspnet/EntityFrameworkCore/issues/13610) and [#9914](https://github.com/aspnet/EntityFrameworkCore/issues/9914))**: This feature is about enabling entities that store data in indexed properties instead of regular properties, and also about being able to use instances of the same .NET class (potentially something as simple as a `Dictionary<string, object>`) to represent different entity types in the same EF Core model.
-  This feature is a stepping stone to support many-to-many relationships without a join entity, which is one of the most requested improvements for EF Core.
-
-- **EF 6.3 on .NET Core ([EF6 #271](https://github.com/aspnet/EntityFramework6/issues/271))**: We understand that many existing applications use previous versions of EF, and that porting them to EF Core only to take advantage of .NET Core can sometimes require a significant effort.
-  For that reason, we will be adapting the next version of EF 6 to run on .NET Core 3.0.
-  We are doing this to facilitate porting existing applications with minimal changes.
-  There are going to be some limitations (for example, it will require new providers, spatial support with SQL Server won't be enabled), and there are no new features planned for EF 6.
-
-In the meantime, you can use [this query in our issue tracker](https://github.com/aspnet/EntityFrameworkCore/issues?q=is%3Aopen+is%3Aissue+milestone%3A3.0.0+sort%3Areactions-%2B1-desc) to see work items tentatively assigned to 3.0.
+See [What's new in EF Core 3.0](xref://core/what-is-new/ef-core-3.0/index) for release details, planned [new features](xref://core/what-is-new/ef-core-3.0/features), and intentional [breaking changes](xref://core/what-is-new/ef-core-3.0/breaking-changes) included in EF Core 3.0.   
 
 ## Schedule
 
@@ -79,9 +48,9 @@ However, we can summarize the common questions we try to answer when deciding wh
 
 2. **What are the workarounds people can use if we don't implement this feature yet?** For example, many developers can map a join table to work around lack of native many-to-many support. Obviously, not all developers want to do it, but many can, and that counts as a factor in our decision.
 
-3. **Does implementing this feature evolve the architecture of EF Core such that it moves us closer to implementing other features?** We tend to favor features that act as building blocks for other features. For example, property bag entities can help us move towards many-to-many support, and entity constructors enabled our lazy loading support. 
+3. **Does implementing this feature evolve the architecture of EF Core such that it moves us closer to implementing other features?** We tend to favor features that act as building blocks for other features. For example, property bag entities can help us move towards many-to-many support, and entity constructors enabled our lazy loading support.
 
-4. **Is the feature an extensibility point?** We tend to favor extensibility points over normal features because they enable developers to hook their own behaviors and compensate for any missing functionality. 
+4. **Is the feature an extensibility point?** We tend to favor extensibility points over normal features because they enable developers to hook their own behaviors and compensate for any missing functionality.
 
 5. **What is the synergy of the feature when used in combination with other products?** We favor features that enable or significantly improve the experience of using EF Core with other products, such as .NET Core, the latest version of Visual Studio, Microsoft Azure, etc.
 

--- a/entity-framework/toc.md
+++ b/entity-framework/toc.md
@@ -12,6 +12,9 @@
 
 ### [What's New](core/what-is-new/index.md)
 #### [EF Core Roadmap](core/what-is-new/roadmap.md)
+#### [EF Core 3.0 (in preview)](core/what-is-new/ef-core-3.0/index.md)
+##### [New features](core/what-is-new/ef-core-3.0/features.md)
+##### [Breaking changes](core/what-is-new/ef-core-3.0/breaking-changes.md)
 #### [EF Core 2.2 (latest stable release)](core/what-is-new/ef-core-2.2.md)
 #### [EF Core 2.1](core/what-is-new/ef-core-2.1.md)
 #### [EF Core 2.0](core/what-is-new/ef-core-2.0.md)


### PR DESCRIPTION
We discussed the fact that we want to have breaking changes and new feature descriptions in the documentation which is a more permanent medium than announcements or blogs. 

Here is a proposal for how things can be organized for the 3.0 release.