### PR TITLE
Removing reference to App Fabric CAT team blog

### DIFF
--- a/entity-framework/ef6/fundamentals/performance/perf-whitepaper.md
+++ b/entity-framework/ef6/fundamentals/performance/perf-whitepaper.md
@@ -314,8 +314,6 @@ The ability to compose over any LINQ query is extremely useful; to do this, you 
 
 Some components will make use of composed IQueryable objects to enable advanced functionality. For example, ASP.NET’s GridView can be data-bound to an IQueryable object via the SelectMethod property. The GridView will then compose over this IQueryable object to allow sorting and paging over the data model. As you can see, using a CompiledQuery for the GridView would not hit the compiled query but would generate a new autocompiled query.
 
-The Customer Advisory Team discusses this in their "Potential Performance Issues with Compiled LINQ Query Re-Compiles" blog post: <http://blogs.msdn.com/b/appfabriccat/archive/2010/08/06/potential-performance-issues-with-compiled-linq-query-re-compiles.aspx>.
-
 One place where you may run into this is when adding progressive filters to a query. For example, suppose you had a Customers page with several drop-down lists for optional filters (for example, Country and OrdersCount). You can compose these filters over the IQueryable results of a CompiledQuery, but doing so will result in the new query going through the plan compiler every time you execute it.
 
 ``` csharp


### PR DESCRIPTION
The blog has been removed, and it didn't add enough that isn't explained here.  

Fixes #1300.