### PR TITLE
Suggested improvement to the wording of the warning for the EF Core Raw SQL Document

### DIFF
--- a/entity-framework/core/querying/raw-sql.md
+++ b/entity-framework/core/querying/raw-sql.md
@@ -134,6 +134,6 @@ There are a few limitations to be aware of when using raw SQL queries:
 * SQL statements other than `SELECT` are recognized automatically as non-composable. As a consequence, the full results of stored procedures are always returned to the client and any LINQ operators applied after `FromSql` are evaluated in-memory.
 
 > [!WARNING]  
-> **Always use parameterization for raw SQL queries:** APIs that accept a raw SQL string such as `FromSql` and `ExecuteSqlCommand` allow values to be easily passed as parameters. In addition to validating user input, always use parameterization for any values used in a raw SQL query/command. If you are using string concatenation to dynamically build any part of the query string then you are responsible for validating any input to protect against SQL injection attacks.
->
-> While the string interpolation and params methods protect `FromSql` and `ExecuteSqlCommand` from SQL Injection Attacks, neither can protect attacks against *non-parameterised dynamic sql* in the SQL string or stored procedures.
+> **Always use parameterization for raw SQL queries:** In addition to validating user input, always use parameterization for any values used in a raw SQL query/command. APIs that accept a raw SQL string such as `FromSql` and `ExecuteSqlCommand` allow values to be easily passed as parameters. Overloads of `FromSql` and `ExecuteSqlCommand` that accept FormattableString also allow using string interpolation syntaxt in a way that helps protect against SQL injection attacks. 
+> 
+> If you are using string concatenation or interpolation to dynamically build any part of the query string, or passing use input to statements or stored procedures that can execute those strings as dynamic SQL, then you are responsible for validating any input to protect against SQL injection attacks.

--- a/entity-framework/core/querying/raw-sql.md
+++ b/entity-framework/core/querying/raw-sql.md
@@ -134,4 +134,4 @@ There are a few limitations to be aware of when using raw SQL queries:
 * SQL statements other than `SELECT` are recognized automatically as non-composable. As a consequence, the full results of stored procedures are always returned to the client and any LINQ operators applied after `FromSql` are evaluated in-memory.
 
 > [!WARNING]  
-> **Always use parameterization for raw SQL queries:** APIs that accept a raw SQL string such as `FromSql` and `ExecuteSqlCommand` allow values to be easily passed as parameters. In addition to validating user input, always use parameterization for any values used in a raw SQL query/command. If you are using string concatenation to dynamically build any part of the query string then you are responsible for validating any input to protect against SQL injection attacks.
+> **Always use parameterization for raw SQL queries:** While the string interpolation and params methods protect `FromSql` and `ExecuteSqlCommand` from SQL Injection Attacks, neither can protect attacks against *non-parameterised dynamic sql* in the SQL string or stored procedures.

--- a/entity-framework/core/querying/raw-sql.md
+++ b/entity-framework/core/querying/raw-sql.md
@@ -136,4 +136,4 @@ There are a few limitations to be aware of when using raw SQL queries:
 > [!WARNING]  
 > **Always use parameterization for raw SQL queries:** In addition to validating user input, always use parameterization for any values used in a raw SQL query/command. APIs that accept a raw SQL string such as `FromSql` and `ExecuteSqlCommand` allow values to be easily passed as parameters. Overloads of `FromSql` and `ExecuteSqlCommand` that accept FormattableString also allow using string interpolation syntaxt in a way that helps protect against SQL injection attacks. 
 > 
-> If you are using string concatenation or interpolation to dynamically build any part of the query string, or passing use input to statements or stored procedures that can execute those strings as dynamic SQL, then you are responsible for validating any input to protect against SQL injection attacks.
+> If you are using string concatenation or interpolation to dynamically build any part of the query string, or passing user input to statements or stored procedures that can execute those inputs as dynamic SQL, then you are responsible for validating any input to protect against SQL injection attacks.

--- a/entity-framework/core/querying/raw-sql.md
+++ b/entity-framework/core/querying/raw-sql.md
@@ -134,4 +134,6 @@ There are a few limitations to be aware of when using raw SQL queries:
 * SQL statements other than `SELECT` are recognized automatically as non-composable. As a consequence, the full results of stored procedures are always returned to the client and any LINQ operators applied after `FromSql` are evaluated in-memory.
 
 > [!WARNING]  
-> **Always use parameterization for raw SQL queries:** While the string interpolation and params methods protect `FromSql` and `ExecuteSqlCommand` from SQL Injection Attacks, neither can protect attacks against *non-parameterised dynamic sql* in the SQL string or stored procedures.
+> **Always use parameterization for raw SQL queries:** APIs that accept a raw SQL string such as `FromSql` and `ExecuteSqlCommand` allow values to be easily passed as parameters. In addition to validating user input, always use parameterization for any values used in a raw SQL query/command. If you are using string concatenation to dynamically build any part of the query string then you are responsible for validating any input to protect against SQL injection attacks.
+>
+> While the string interpolation and params methods protect `FromSql` and `ExecuteSqlCommand` from SQL Injection Attacks, neither can protect attacks against *non-parameterised dynamic sql* in the SQL string or stored procedures.


### PR DESCRIPTION
See [this issue](https://github.com/aspnet/EntityFramework.Docs/issues/1295) for previous discussion and correspondence with @divega .

The purpose of this update is to clarify that; while both string interpolation and params methods provide protection against SQL Injection, Entity Framework cannot protect your application against non-parameterized dynamic sql.

I believe this update will provide clarification for those making comments on the article. It may also help ensure that people check their stored procedures as well as their EF code when doing security reviews.