### PR TITLE
Made the property DateCreated in class BlogDetails non-nullable.

### DIFF
--- a/entity-framework/ef6/modeling/code-first/data-annotations.md
+++ b/entity-framework/ef6/modeling/code-first/data-annotations.md
@@ -207,7 +207,7 @@ It’s not uncommon to describe your domain entities across a set of classes and
 ``` csharp
     public class BlogDetails
     {
-        public DateTime? DateCreated { get; set; }
+        public DateTime DateCreated { get; set; }
 
         [MaxLength(250)]
         public string Description { get; set; }
@@ -222,7 +222,7 @@ However as a property in the Blog class, BlogDetails it will be tracked as part 
     [ComplexType]
     public class BlogDetails
     {
-        public DateTime? DateCreated { get; set; }
+        public DateTime DateCreated { get; set; }
 
         [MaxLength(250)]
         public string Description { get; set; }


### PR DESCRIPTION
It appears the intent in the ComplexType code example was to make the DateCreated property non-nullable.  This is confirmed by this excerpt in the document: "Another interesting note is that although the DateCreated property was defined as a non-nullable DateTime in the class, the relevant database field is nullable. You must use the Required annotation if you wish to affect the database schema."