### PR TITLE
Fixed a bug in the Constructor of Department class

### DIFF
--- a/entity-framework/ef6/fundamentals/relationships.md
+++ b/entity-framework/ef6/fundamentals/relationships.md
@@ -45,7 +45,7 @@ public class Department
 {
    public Department()
    {
-     this.Course = new HashSet<Course>();
+     this.Courses = new HashSet<Course>();
    }  
    public int DepartmentID { get; set; }
    public string Name { get; set; }


### PR DESCRIPTION
The code snippet which shows the Department Model class has bug. I changed this.Course = new HashSet<Course>(); to this.Courses = new HashSet<Course>();