### PR TITLE
Update SQLite limitation md - Support RenameColumn

### DIFF
--- a/entity-framework/core/providers/sqlite/limitations.md
+++ b/entity-framework/core/providers/sqlite/limitations.md
@@ -35,7 +35,7 @@ The SQLite database engine does not support a number of schema operations that a
 | DropPrimaryKey       | ✗          |                  |
 | DropTable            | ✔          | 1.0              |
 | DropUniqueConstraint | ✗          |                  |
-| RenameColumn         | ✗          |                  |
+| RenameColumn         | ✔          | 2.2.2            |
 | RenameIndex          | ✔          | 2.1              |
 | RenameTable          | ✔          | 1.0              |
 | EnsureSchema         | ✔ (no-op)  | 2.0              |


### PR DESCRIPTION
From version 2.2.2 EntityFrameworkCore supports RenameColumn in SQLite provider.