### PR TITLE
Add .NET universal header

### DIFF
--- a/entity-framework/docfx.json
+++ b/entity-framework/docfx.json
@@ -77,7 +77,8 @@
       "ms.author": "divega",
       "feedback_system": "GitHub",
       "feedback_github_repo": "aspnet/EntityFramework.Docs",
-      "feedback_product_url": "https://github.com/aspnet/EntityFrameworkCore/issues/new"
+      "feedback_product_url": "https://github.com/aspnet/EntityFrameworkCore/issues/new",
+      "uhfHeaderId": "MSDocsHeader-DotNet"
     },
     "fileMetadata": {
       "feedback_product_url": {


### PR DESCRIPTION
This will put the same header on the EF docs that is used on the [.NET website](https://dotnet.microsoft.com/) and [main .NET docs](https://docs.microsoft.com/en-us/dotnet/).

Here is an example of this setting in use in the main .NET docs https://github.com/dotnet/docs/blob/master/docfx.json#L108.