### PR TITLE
Fix wrong NavProp reference.

### DIFF
--- a/entity-framework/core/querying/related-data.md
+++ b/entity-framework/core/querying/related-data.md
@@ -103,7 +103,7 @@ Contents of `School` navigation of all People who are Students can be eagerly lo
 
 - using overload of `Include` that takes parameter of type `string`
   ```csharp
-  context.People.Include("Student").ToList()
+  context.People.Include("School").ToList()
   ```
 
 ### Ignored includes


### PR DESCRIPTION
Fix for #1370. Typo - correct to use the NavProp and not the name of the derived class (the existing code snippet doesn't work).