### PR TITLE
The word was slightly misspelled

### DIFF
--- a/entity-framework/core/what-is-new/ef-core-3.0/breaking-changes.md
+++ b/entity-framework/core/what-is-new/ef-core-3.0/breaking-changes.md
@@ -627,7 +627,7 @@ Starting with 3.0, EF Core closes the connection as soon as it's done using it.
 
 **Why**
 
-This change allows to use multiple contexts in the same `TransactionScope`. The new behavior alose matches EF6.
+This change allows to use multiple contexts in the same `TransactionScope`. The new behavior also matches EF6.
 
 **Mitigations**
 


### PR DESCRIPTION
Tracking Issue #14218 - Changed from "alose" to "also".