### PR TITLE
Add alternative method for reference loop handling

### DIFF
--- a/entity-framework/core/querying/related-data.md
+++ b/entity-framework/core/querying/related-data.md
@@ -330,4 +330,4 @@ public void ConfigureServices(IServiceCollection services)
 }
 ```
 
-Or you could decorate the inverse navigation property with the `JsonIgnore` attribute.
+Another alternative is to decorate one of the navigation properties with the `[JsonIgnore]` attribute, which instructs Json.NET to not traverse that navigation property while serializing.

--- a/entity-framework/core/querying/related-data.md
+++ b/entity-framework/core/querying/related-data.md
@@ -329,3 +329,5 @@ public void ConfigureServices(IServiceCollection services)
     ...
 }
 ```
+
+Or you could decorate the inverse navigation property with the `JsonIgnore` attribute.


### PR DESCRIPTION
You can use the `[JsonIgnore]` attribute to ignore serializing a inverse navigation property to prevent a reference loop.