### PR TITLE
Increase indent in IncludeTree sample

### DIFF
--- a/samples/core/Querying/Querying/RelatedData/Sample.cs
+++ b/samples/core/Querying/Querying/RelatedData/Sample.cs
@@ -79,7 +79,7 @@ namespace EFQuerying.RelatedData
                 var blogs = context.Blogs
                     .Include(blog => blog.Posts)
                         .ThenInclude(post => post.Author)
-                        .ThenInclude(author => author.Photo)
+                            .ThenInclude(author => author.Photo)
                     .Include(blog => blog.Owner)
                         .ThenInclude(owner => owner.Photo)
                     .ToList();


### PR DESCRIPTION
Increase indent for ThenInclude of `author.Photo`, so it matches the other samples (see `MultipleThenIncludes`)