### PR TITLE
Added hyperlink to 'migrations' for easy access

### DIFF
--- a/entity-framework/core/get-started/netcore/new-db-sqlite.md
+++ b/entity-framework/core/get-started/netcore/new-db-sqlite.md
@@ -10,7 +10,7 @@ uid: core/get-started/netcore/new-db-sqlite
 
 # Getting Started with EF Core on .NET Core Console App with a New database
 
-In this tutorial, you create a .NET Core console app that performs data access against a SQLite database using Entity Framework Core. You use migrations to create the database from the model. See [ASP.NET Core - New database](xref:core/get-started/aspnetcore/new-db) for a Visual Studio version using ASP.NET Core MVC.
+In this tutorial, you create a .NET Core console app that performs data access against a SQLite database using Entity Framework Core. You use [migrations](xref:core/managing-schemas/migrations/index) to create the database from the model. See [ASP.NET Core - New database](xref:core/get-started/aspnetcore/new-db) for a Visual Studio version using ASP.NET Core MVC.
 
 [View this article's sample on GitHub](https://github.com/aspnet/EntityFramework.Docs/tree/master/samples/core/GetStarted/NetCore/ConsoleApp.SQLite).
 


### PR DESCRIPTION
Hyperlink from first 'migration' keyword in the document (at very top) is missing. So added hyperlink to 'migrations' for easy access.