### PR TITLE
Update relationships.md

### DIFF
--- a/entity-framework/core/modeling/relationships.md
+++ b/entity-framework/core/modeling/relationships.md
@@ -388,7 +388,7 @@ class MyContext : DbContext
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         modelBuilder.Entity<PostTag>()
-            .HasKey(t => new { t.PostId, t.TagId });
+            .HasKey(pt => new { pt.PostId, pt.TagId });
 
         modelBuilder.Entity<PostTag>()
             .HasOne(pt => pt.Post)


### PR DESCRIPTION
Updated the arrow function variable names to be more consistent with the other functions below it.

Below, the variable `t` refers to a `Tag` entity. However, it's really should be named `pt` as it's referring to a `PostTag` entity.