### PR TITLE
Update doc on migrations

### DIFF
--- a/entity-framework/core/managing-schemas/migrations/index.md
+++ b/entity-framework/core/managing-schemas/migrations/index.md
@@ -20,7 +20,10 @@ Migrations includes command-line tools and APIs that help with the following tas
 * [Generate SQL scripts](#generate-sql-scripts). You might need a script to update a production database or to troubleshoot migration code.
 * [Apply migrations at runtime](#apply-migrations-at-runtime). When design-time updates and running scripts aren't the best options, call the `Migrate()` method.
 
-> [!NOTE] If your DbContext class is in a different assembly than your startup project, you need to specifiy your project and startup project by adding `-Project <A> -StartupProject <B>` to all PowerShell commands below, or `--project <A> --startup-project <B>` to all dotnet commands, where `<A>` is the project containing the class extending DbContext, and `<B>` is the startup project.
+If the `DbContext` is in a different assembly than the startup project, specify the project and startup project by adding one of the following:
+
+- `-Project <project with DbContext> -StartupProject <start up project>` to all PowerShell commands.
+- `--project <project with DbContext> --startup-project <start up project>` to all dotnet commands.
 
 Install the tools
 -----------------

--- a/entity-framework/core/managing-schemas/migrations/index.md
+++ b/entity-framework/core/managing-schemas/migrations/index.md
@@ -20,7 +20,7 @@ Migrations includes command-line tools and APIs that help with the following tas
 * [Generate SQL scripts](#generate-sql-scripts). You might need a script to update a production database or to troubleshoot migration code.
 * [Apply migrations at runtime](#apply-migrations-at-runtime). When design-time updates and running scripts aren't the best options, call the `Migrate()` method.
 
-If the `DbContext` is in a different assembly than the startup project, specify the project and startup project by adding one of the following:
+If the `DbContext` is in a different assembly than the startup project, specify the project and startup project:
 
 - `-Project <project with DbContext> -StartupProject <start up project>` to all PowerShell commands.
 - `--project <project with DbContext> --startup-project <start up project>` to all dotnet commands.

--- a/entity-framework/core/managing-schemas/migrations/index.md
+++ b/entity-framework/core/managing-schemas/migrations/index.md
@@ -20,6 +20,8 @@ Migrations includes command-line tools and APIs that help with the following tas
 * [Generate SQL scripts](#generate-sql-scripts). You might need a script to update a production database or to troubleshoot migration code.
 * [Apply migrations at runtime](#apply-migrations-at-runtime). When design-time updates and running scripts aren't the best options, call the `Migrate()` method.
 
+> [!NOTE] If your DbContext class is in a different assembly than your startup project, you need to specifiy your project and startup project by adding `-Project <A> -StartupProject <B>` to all PowerShell commands below, or `--project <A> --startup-project <B>` to all dotnet commands, where `<A>` is the project containing the class extending DbContext, and `<B>` is the startup project.
+
 Install the tools
 -----------------
 

--- a/entity-framework/core/managing-schemas/migrations/index.md
+++ b/entity-framework/core/managing-schemas/migrations/index.md
@@ -20,10 +20,8 @@ Migrations includes command-line tools and APIs that help with the following tas
 * [Generate SQL scripts](#generate-sql-scripts). You might need a script to update a production database or to troubleshoot migration code.
 * [Apply migrations at runtime](#apply-migrations-at-runtime). When design-time updates and running scripts aren't the best options, call the `Migrate()` method.
 
-If the `DbContext` is in a different assembly than the startup project, specify the project and startup project:
-
-- `-Project <project with DbContext> -StartupProject <start up project>` to all PowerShell commands.
-- `--project <project with DbContext> --startup-project <start up project>` to all dotnet commands.
+> [!TIP]
+> If the `DbContext` is in a different assembly than the startup project, you can specify the target and startup projects in the the [PowerShell migrations commands](https://docs.microsoft.com/en-us/ef/core/miscellaneous/cli/powershell#target-and-startup-project) or in the [`dotnet ef` command-line tool](https://docs.microsoft.com/en-us/ef/core/miscellaneous/cli/dotnet#target-project-and-startup-project).
 
 Install the tools
 -----------------


### PR DESCRIPTION
- Add note about using different assemblies for the database and startup.

This information would've been very useful to our team if it was mentioned here, and would've saved us a lot of time and head scratching.