### PR TITLE
On every other page 'Data Annotations' is on top

### DIFF
--- a/entity-framework/core/modeling/index.md
+++ b/entity-framework/core/modeling/index.md
@@ -14,14 +14,14 @@ This article covers configuration that can be applied to a model targeting any d
 > [!TIP]  
 > You can view this article’s [sample](https://github.com/aspnet/EntityFramework.Docs/tree/master/samples) on GitHub.
 
-## Use fluent API to configure a model
-
-You can override the `OnModelCreating` method in your derived context and use the `ModelBuilder API` to configure your model. This is the most powerful method of configuration and allows configuration to be specified without modifying your entity classes. Fluent API configuration has the highest precedence and will override conventions and data annotations.
-
-[!code-csharp[Main](../../../samples/core/Modeling/FluentAPI/Samples/Required.cs?highlight=11-13)]
-
 ## Use data annotations to configure a model
 
 You can also apply attributes (known as Data Annotations) to your classes and properties. Data annotations will override conventions, but will be overridden by Fluent API configuration.
 
 [!code-csharp[Main](../../../samples/core/Modeling/DataAnnotations/Samples/Required.cs?highlight=14)]
+
+## Use fluent API to configure a model
+
+You can override the `OnModelCreating` method in your derived context and use the `ModelBuilder API` to configure your model. This is the most powerful method of configuration and allows configuration to be specified without modifying your entity classes. Fluent API configuration has the highest precedence and will override conventions and data annotations.
+
+[!code-csharp[Main](../../../samples/core/Modeling/FluentAPI/Samples/Required.cs?highlight=11-13)]


### PR DESCRIPTION
On every other page 'Data Annotations' option is on top, and Fluent API is on the bottom, to keep this in 1 structure I moved Fluent API down 1 section.

If possible try to tabify this where the visitor can select if they use Fleunt API or Data Annotations.