### PR TITLE
Remove Redundant catch

### DIFF
--- a/entity-framework/ef6/saving/transactions.md
+++ b/entity-framework/ef6/saving/transactions.md
@@ -60,27 +60,20 @@ namespace TransactionsExamples
             {
                 using (var dbContextTransaction = context.Database.BeginTransaction())
                 {
-                    try
+                    context.Database.ExecuteSqlCommand(
+                        @"UPDATE Blogs SET Rating = 5" +
+                            " WHERE Name LIKE '%Entity Framework%'"
+                        );
+
+                    var query = context.Posts.Where(p => p.Blog.Rating >= 5);
+                    foreach (var post in query)
                     {
-                        context.Database.ExecuteSqlCommand(
-                            @"UPDATE Blogs SET Rating = 5" +
-                                " WHERE Name LIKE '%Entity Framework%'"
-                            );
-
-                        var query = context.Posts.Where(p => p.Blog.Rating >= 5);
-                        foreach (var post in query)
-                        {
-                            post.Title += "[Cool Blog]";
-                        }
-
-                        context.SaveChanges();
-
-                        dbContextTransaction.Commit();
+                        post.Title += "[Cool Blog]";
                     }
-                    catch (Exception)
-                    {
-                        dbContextTransaction.Rollback();
-                    }
+
+                    context.SaveChanges();
+
+                    dbContextTransaction.Commit();
                 }
             }
         }
@@ -134,35 +127,28 @@ namespace TransactionsExamples
 
                using (var sqlTxn = conn.BeginTransaction(System.Data.IsolationLevel.Snapshot))
                {
-                   try
-                   {
-                       var sqlCommand = new SqlCommand();
-                       sqlCommand.Connection = conn;
-                       sqlCommand.Transaction = sqlTxn;
-                       sqlCommand.CommandText =
-                           @"UPDATE Blogs SET Rating = 5" +
-                            " WHERE Name LIKE '%Entity Framework%'";
-                       sqlCommand.ExecuteNonQuery();
+                   var sqlCommand = new SqlCommand();
+                   sqlCommand.Connection = conn;
+                   sqlCommand.Transaction = sqlTxn;
+                   sqlCommand.CommandText =
+                       @"UPDATE Blogs SET Rating = 5" +
+                        " WHERE Name LIKE '%Entity Framework%'";
+                   sqlCommand.ExecuteNonQuery();
 
-                       using (var context =  
-                         new BloggingContext(conn, contextOwnsConnection: false))
-                        {
-                            context.Database.UseTransaction(sqlTxn);
-
-                            var query =  context.Posts.Where(p => p.Blog.Rating >= 5);
-                            foreach (var post in query)
-                            {
-                                post.Title += "[Cool Blog]";
-                            }
-                           context.SaveChanges();
-                        }
-
-                        sqlTxn.Commit();
-                    }
-                    catch (Exception)
+                   using (var context =  
+                     new BloggingContext(conn, contextOwnsConnection: false))
                     {
-                        sqlTxn.Rollback();
+                        context.Database.UseTransaction(sqlTxn);
+
+                        var query =  context.Posts.Where(p => p.Blog.Rating >= 5);
+                        foreach (var post in query)
+                        {
+                            post.Title += "[Cool Blog]";
+                        }
+                       context.SaveChanges();
                     }
+
+                    sqlTxn.Commit();
                 }
             }
         }

--- a/samples/core/Saving/Saving/Transactions/ControllingTransaction/Sample.cs
+++ b/samples/core/Saving/Saving/Transactions/ControllingTransaction/Sample.cs
@@ -19,26 +19,19 @@ namespace EFSaving.Transactions.ControllingTransaction
             {
                 using (var transaction = context.Database.BeginTransaction())
                 {
-                    try
-                    {
-                        context.Blogs.Add(new Blog { Url = "http://blogs.msdn.com/dotnet" });
-                        context.SaveChanges();
+                    context.Blogs.Add(new Blog { Url = "http://blogs.msdn.com/dotnet" });
+                    context.SaveChanges();
 
-                        context.Blogs.Add(new Blog { Url = "http://blogs.msdn.com/visualstudio" });
-                        context.SaveChanges();
+                    context.Blogs.Add(new Blog { Url = "http://blogs.msdn.com/visualstudio" });
+                    context.SaveChanges();
 
-                        var blogs = context.Blogs
-                            .OrderBy(b => b.Url)
-                            .ToList();
+                    var blogs = context.Blogs
+                        .OrderBy(b => b.Url)
+                        .ToList();
 
-                        // Commit transaction if all commands succeed, transaction will auto-rollback
-                        // when disposed if either commands fails
-                        transaction.Commit();
-                    }
-                    catch (Exception)
-                    {
-                        // TODO: Handle failure
-                    }
+                    // Commit transaction if all commands succeed, transaction will auto-rollback
+                    // when disposed if either commands fails
+                    transaction.Commit();
                 }
             }
             #endregion

--- a/samples/core/Saving/Saving/Transactions/SharingTransaction/Sample.cs
+++ b/samples/core/Saving/Saving/Transactions/SharingTransaction/Sample.cs
@@ -30,28 +30,21 @@ namespace EFSaving.Transactions.SharingTransaction
             {
                 using (var transaction = context1.Database.BeginTransaction())
                 {
-                    try
+                    context1.Blogs.Add(new Blog { Url = "http://blogs.msdn.com/dotnet" });
+                    context1.SaveChanges();
+
+                    using (var context2 = new BloggingContext(options))
                     {
-                        context1.Blogs.Add(new Blog { Url = "http://blogs.msdn.com/dotnet" });
-                        context1.SaveChanges();
+                        context2.Database.UseTransaction(transaction.GetDbTransaction());
 
-                        using (var context2 = new BloggingContext(options))
-                        {
-                            context2.Database.UseTransaction(transaction.GetDbTransaction());
-
-                            var blogs = context2.Blogs
-                                .OrderBy(b => b.Url)
-                                .ToList();
-                        }
-
-                        // Commit transaction if all commands succeed, transaction will auto-rollback
-                        // when disposed if either commands fails
-                        transaction.Commit();
+                        var blogs = context2.Blogs
+                            .OrderBy(b => b.Url)
+                            .ToList();
                     }
-                    catch (Exception)
-                    {
-                        // TODO: Handle failure
-                    }
+
+                    // Commit transaction if all commands succeed, transaction will auto-rollback
+                    // when disposed if either commands fails
+                    transaction.Commit();
                 }
             }
             #endregion


### PR DESCRIPTION
unless better advice than `// TODO: Handle failure` can be given, it would be better to let the exception bubble. leaving a todo and a swallow exception is likely to get copies as is to peoples production code