### PR TITLE
add ForSqlServerHasIndex sample

### DIFF
--- a/entity-framework/core/modeling/relational/indexes.md
+++ b/entity-framework/core/modeling/relational/indexes.md
@@ -33,3 +33,9 @@ You can also specify a filter.
 When using the SQL Server provider EF adds a 'IS NOT NULL' filter for all nullable columns that are part of a unique index. To override this convention you can supply a `null` value.
 
 [!code-csharp[Main](../../../../samples/core/Modeling/FluentAPI/Samples/Relational/IndexNoFilter.cs?name=Model&highlight=10)]
+
+### Include Columns in SQL Server Indexes
+
+You can configure [indexes with included columns](https://docs.microsoft.com/en-us/sql/relational-databases/indexes/create-indexes-with-included-columns?view=sql-server-2017) to significantly improve query performance when all columns in the query are included in the index as key or nonkey columns.
+
+[!code-csharp[Main](../../../../samples/core/Modeling/FluentAPI/Samples/Relational/ForSqlServerHasIndex.cs?name=Model)]

--- a/entity-framework/core/modeling/relational/indexes.md
+++ b/entity-framework/core/modeling/relational/indexes.md
@@ -36,6 +36,6 @@ When using the SQL Server provider EF adds a 'IS NOT NULL' filter for all nullab
 
 ### Include Columns in SQL Server Indexes
 
-You can configure [indexes with included columns](https://docs.microsoft.com/en-us/sql/relational-databases/indexes/create-indexes-with-included-columns?view=sql-server-2017) to significantly improve query performance when all columns in the query are included in the index as key or nonkey columns.
+You can configure [indexes with included columns](https://docs.microsoft.com/sql/relational-databases/indexes/create-indexes-with-included-columns) to significantly improve query performance when all columns in the query are included in the index as key or non-key columns.
 
 [!code-csharp[Main](../../../../samples/core/Modeling/FluentAPI/Samples/Relational/ForSqlServerHasIndex.cs?name=Model)]

--- a/samples/core/Modeling/FluentAPI/Samples/Relational/ForSqlServerHasIndex.cs
+++ b/samples/core/Modeling/FluentAPI/Samples/Relational/ForSqlServerHasIndex.cs
@@ -1,0 +1,32 @@
+using System;
+using Microsoft.EntityFrameworkCore;
+
+namespace EFModeling.Configuring.FluentAPI.Samples.Relational.ForSqlServerHasIndex
+{
+    #region Model
+    class MyContext : DbContext
+    {
+        public DbSet<Post> Posts { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Post>()
+                .ForSqlServerHasIndex(p => p.Url)
+                .ForSqlServerInclude(p => new
+                {
+                    p.Title,
+                    p.PublishedOn
+                })
+                .HasName("Index_Url_Include_Title_PublishedOn");
+        }
+    }
+
+    public class Post
+    {
+        public int PostId { get; set; }
+        public string Url { get; set; }
+        public string Title { get; set; }
+        public DateTime PublishedOn { get; set; }
+    }
+    #endregion
+}


### PR DESCRIPTION
There doesn't seem to be any documentation around this feature, I only discovered it through GitHub issues requesting the feature to be added. 

I also noticed `ForSqlServerHasIndex` has been removed in a breaking change on aspnet/EntityFrameworkCore#12366 and replaced with `HasIndex`, but this still holds for `ForSqlServerInclude`.