### PR TITLE
remove ConnectRetryCount=0 from connection strings

### DIFF
--- a/samples/core/CompiledQueries/Model/AdventureWorksContext.cs
+++ b/samples/core/CompiledQueries/Model/AdventureWorksContext.cs
@@ -10,7 +10,7 @@ namespace Samples.Model
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
             optionsBuilder.UseSqlServer(
-                "data source=(localdb)\\mssqllocaldb;initial catalog=AdventureWorks2014;integrated security=True;MultipleActiveResultSets=True;ConnectRetryCount=0");
+                "data source=(localdb)\\mssqllocaldb;initial catalog=AdventureWorks2014;integrated security=True;MultipleActiveResultSets=True");
         }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/samples/core/DbContextPooling/Program.cs
+++ b/samples/core/DbContextPooling/Program.cs
@@ -20,7 +20,7 @@ namespace Samples
         public static long InstanceCount;
 
         public BloggingContext(DbContextOptions options)
-            : base(options) 
+            : base(options)
             => Interlocked.Increment(ref InstanceCount);
 
         public DbSet<Blog> Blogs { get; set; }
@@ -38,7 +38,7 @@ namespace Samples
     public class Startup
     {
         private const string ConnectionString
-            = @"Server=(localdb)\mssqllocaldb;Database=Demo.ContextPooling;Integrated Security=True;ConnectRetryCount=0";
+            = @"Server=(localdb)\mssqllocaldb;Database=Demo.ContextPooling;Integrated Security=True";
 
         public void ConfigureServices(IServiceCollection services)
         {

--- a/samples/core/GetStarted/AspNetCore/EFGetStarted.AspNetCore.ExistingDb/Startup.cs
+++ b/samples/core/GetStarted/AspNetCore/EFGetStarted.AspNetCore.ExistingDb/Startup.cs
@@ -39,7 +39,7 @@ namespace EFGetStarted.AspNetCore.ExistingDb
 
             services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
 
-            var connection = @"Server=(localdb)\mssqllocaldb;Database=Blogging;Trusted_Connection=True;ConnectRetryCount=0";
+            var connection = @"Server=(localdb)\mssqllocaldb;Database=Blogging;Trusted_Connection=True";
             services.AddDbContext<BloggingContext>(options => options.UseSqlServer(connection));
         }
 #endregion

--- a/samples/core/GetStarted/AspNetCore/EFGetStarted.AspNetCore.NewDb/Startup.cs
+++ b/samples/core/GetStarted/AspNetCore/EFGetStarted.AspNetCore.NewDb/Startup.cs
@@ -38,7 +38,7 @@ namespace EFGetStarted.AspNetCore.NewDb
 
             services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
 
-            var connection = @"Server=(localdb)\mssqllocaldb;Database=EFGetStarted.AspNetCore.NewDb;Trusted_Connection=True;ConnectRetryCount=0";
+            var connection = @"Server=(localdb)\mssqllocaldb;Database=EFGetStarted.AspNetCore.NewDb;Trusted_Connection=True";
             services.AddDbContext<BloggingContext>
                 (options => options.UseSqlServer(connection));
             // BloggingContext requires

--- a/samples/core/Miscellaneous/Logging/Logging/BloggingContext.cs
+++ b/samples/core/Miscellaneous/Logging/Logging/BloggingContext.cs
@@ -18,7 +18,7 @@ namespace EFLogging
             => optionsBuilder
                 .UseLoggerFactory(MyLoggerFactory) // Warning: Do not create a new ILoggerFactory instance each time
                 .UseSqlServer(
-                    @"Server=(localdb)\mssqllocaldb;Database=EFLogging;Trusted_Connection=True;ConnectRetryCount=0");
+                    @"Server=(localdb)\mssqllocaldb;Database=EFLogging;Trusted_Connection=True");
         #endregion
     }
 }

--- a/samples/core/Miscellaneous/Logging/Logging/BloggingContextWithFiltering.cs
+++ b/samples/core/Miscellaneous/Logging/Logging/BloggingContextWithFiltering.cs
@@ -23,7 +23,7 @@ namespace EFLogging
             => optionsBuilder
                 .UseLoggerFactory(MyLoggerFactory) // Warning: Do not create a new ILoggerFactory instance each time
                 .UseSqlServer(
-                    @"Server=(localdb)\mssqllocaldb;Database=EFLogging;Trusted_Connection=True;ConnectRetryCount=0");
+                    @"Server=(localdb)\mssqllocaldb;Database=EFLogging;Trusted_Connection=True");
         #endregion
     }
 }

--- a/samples/core/Miscellaneous/Testing/BusinessLogic/BloggingContext.cs
+++ b/samples/core/Miscellaneous/Testing/BusinessLogic/BloggingContext.cs
@@ -22,7 +22,7 @@ namespace BusinessLogic
         {
             if (!optionsBuilder.IsConfigured)
             {
-                optionsBuilder.UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EFProviders.InMemory;Trusted_Connection=True;ConnectRetryCount=0");
+                optionsBuilder.UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EFProviders.InMemory;Trusted_Connection=True");
             }
         }
         #endregion

--- a/samples/core/Modeling/DataSeeding/DataSeedingContext.cs
+++ b/samples/core/Modeling/DataSeeding/DataSeedingContext.cs
@@ -9,7 +9,7 @@ namespace EFModeling.Samples.DataSeeding
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder
-                .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EFDataSeeding;Trusted_Connection=True;ConnectRetryCount=0");
+                .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EFDataSeeding;Trusted_Connection=True");
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {

--- a/samples/core/Modeling/OwnedEntities/OwnedEntityContext.cs
+++ b/samples/core/Modeling/OwnedEntities/OwnedEntityContext.cs
@@ -9,7 +9,7 @@ namespace OwnedEntities
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder
-                .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EFOwnedEntity;Trusted_Connection=True;ConnectRetryCount=0");
+                .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EFOwnedEntity;Trusted_Connection=True");
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {

--- a/samples/core/Modeling/TableSplitting/TableSplittingContext.cs
+++ b/samples/core/Modeling/TableSplitting/TableSplittingContext.cs
@@ -9,7 +9,7 @@ namespace TableSplitting
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder
-                .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EFTableSplitting;Trusted_Connection=True;ConnectRetryCount=0");
+                .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EFTableSplitting;Trusted_Connection=True");
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {

--- a/samples/core/Querying/Querying/BloggingContext.cs
+++ b/samples/core/Querying/Querying/BloggingContext.cs
@@ -9,7 +9,7 @@ namespace EFQuerying
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
-            optionsBuilder.UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EFQuerying;Trusted_Connection=True;ConnectRetryCount=0");
+            optionsBuilder.UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EFQuerying;Trusted_Connection=True");
         }
     }
 }

--- a/samples/core/Querying/Querying/ClientEval/ThrowOnClientEval/BloggingContext.cs
+++ b/samples/core/Querying/Querying/ClientEval/ThrowOnClientEval/BloggingContext.cs
@@ -11,7 +11,7 @@ namespace EFQuerying.RelatedData.ThrowOnClientEval
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
             optionsBuilder
-                .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EFQuerying;Trusted_Connection=True;ConnectRetryCount=0")
+                .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EFQuerying;Trusted_Connection=True")
                 .ConfigureWarnings(warnings => warnings.Throw(RelationalEventId.QueryClientEvaluationWarning));
         }
     }

--- a/samples/core/Querying/Querying/RelatedData/ThrowOnIgnoredInclude/BloggingContext.cs
+++ b/samples/core/Querying/Querying/RelatedData/ThrowOnIgnoredInclude/BloggingContext.cs
@@ -12,7 +12,7 @@ namespace EFQuerying.RelatedData.ThrowOnIgnoredInclude
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
             optionsBuilder
-                .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EFQuerying;Trusted_Connection=True;ConnectRetryCount=0")
+                .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EFQuerying;Trusted_Connection=True")
                 .ConfigureWarnings(warnings => warnings.Throw(CoreEventId.IncludeIgnoredWarning));
         }
         #endregion

--- a/samples/core/Saving/Saving/Async/BloggingContext.cs
+++ b/samples/core/Saving/Saving/Async/BloggingContext.cs
@@ -9,7 +9,7 @@ namespace EFSaving.Async
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
-            optionsBuilder.UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EFSaving.Async;Trusted_Connection=True;ConnectRetryCount=0");
+            optionsBuilder.UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EFSaving.Async;Trusted_Connection=True");
         }
     }
 }

--- a/samples/core/Saving/Saving/Basics/BloggingContext.cs
+++ b/samples/core/Saving/Saving/Basics/BloggingContext.cs
@@ -9,7 +9,7 @@ namespace EFSaving.Basics
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
-            optionsBuilder.UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EFSaving.Basics;Trusted_Connection=True;ConnectRetryCount=0");
+            optionsBuilder.UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EFSaving.Basics;Trusted_Connection=True");
         }
     }
 }

--- a/samples/core/Saving/Saving/Concurrency/Sample.cs
+++ b/samples/core/Saving/Saving/Concurrency/Sample.cs
@@ -81,7 +81,7 @@ namespace EFSaving.Concurrency
             {
                 // Requires NuGet package Microsoft.EntityFrameworkCore.SqlServer
                 optionsBuilder.UseSqlServer(
-                    @"Server=(localdb)\mssqllocaldb;Database=EFSaving.Concurrency;Trusted_Connection=True;ConnectRetryCount=0");
+                    @"Server=(localdb)\mssqllocaldb;Database=EFSaving.Concurrency;Trusted_Connection=True");
             }
         }
 

--- a/samples/core/Saving/Saving/Disconnected/BloggingContext.cs
+++ b/samples/core/Saving/Saving/Disconnected/BloggingContext.cs
@@ -9,7 +9,7 @@ namespace EFSaving.Disconnected
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
-            optionsBuilder.UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EFSaving.Disconnected;Trusted_Connection=True;ConnectRetryCount=0");
+            optionsBuilder.UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EFSaving.Disconnected;Trusted_Connection=True");
         }
     }
 }

--- a/samples/core/Saving/Saving/ExplicitValuesGenerateProperties/EmployeeContext.cs
+++ b/samples/core/Saving/Saving/ExplicitValuesGenerateProperties/EmployeeContext.cs
@@ -9,7 +9,7 @@ namespace EFSaving.ExplicitValuesGenerateProperties
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
-            optionsBuilder.UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EFSaving.ExplicitValuesGenerateProperties;Trusted_Connection=True;ConnectRetryCount=0");
+            optionsBuilder.UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EFSaving.ExplicitValuesGenerateProperties;Trusted_Connection=True");
         }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/samples/core/Saving/Saving/RelatedData/Sample.cs
+++ b/samples/core/Saving/Saving/RelatedData/Sample.cs
@@ -74,7 +74,7 @@ namespace EFSaving.RelatedData
 
             protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             {
-                optionsBuilder.UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EFSaving.RelatedData;Trusted_Connection=True;ConnectRetryCount=0");
+                optionsBuilder.UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EFSaving.RelatedData;Trusted_Connection=True");
             }
         }
 

--- a/samples/core/Saving/Saving/Transactions/AmbientTransaction/Sample.cs
+++ b/samples/core/Saving/Saving/Transactions/AmbientTransaction/Sample.cs
@@ -8,7 +8,7 @@ namespace EFSaving.Transactions.AmbientTransaction
     {
         public static void Run()
         {
-            var connectionString = @"Server=(localdb)\mssqllocaldb;Database=EFSaving.Transactions;Trusted_Connection=True;ConnectRetryCount=0";
+            var connectionString = @"Server=(localdb)\mssqllocaldb;Database=EFSaving.Transactions;Trusted_Connection=True";
 
             using (var context = new BloggingContext(
                 new DbContextOptionsBuilder<BloggingContext>()

--- a/samples/core/Saving/Saving/Transactions/CommitableTransaction/Sample.cs
+++ b/samples/core/Saving/Saving/Transactions/CommitableTransaction/Sample.cs
@@ -8,7 +8,7 @@ namespace EFSaving.Transactions.CommitableTransaction
     {
         public static void Run()
         {
-            var connectionString = @"Server=(localdb)\mssqllocaldb;Database=EFSaving.Transactions;Trusted_Connection=True;ConnectRetryCount=0";
+            var connectionString = @"Server=(localdb)\mssqllocaldb;Database=EFSaving.Transactions;Trusted_Connection=True";
 
             using (var context = new BloggingContext(
                 new DbContextOptionsBuilder<BloggingContext>()

--- a/samples/core/Saving/Saving/Transactions/ControllingTransaction/Sample.cs
+++ b/samples/core/Saving/Saving/Transactions/ControllingTransaction/Sample.cs
@@ -50,7 +50,7 @@ namespace EFSaving.Transactions.ControllingTransaction
 
             protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             {
-                optionsBuilder.UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EFSaving.Transactions;Trusted_Connection=True;ConnectRetryCount=0");
+                optionsBuilder.UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EFSaving.Transactions;Trusted_Connection=True");
             }
         }
 

--- a/samples/core/Saving/Saving/Transactions/ExternalDbTransaction/Sample.cs
+++ b/samples/core/Saving/Saving/Transactions/ExternalDbTransaction/Sample.cs
@@ -7,7 +7,7 @@ namespace EFSaving.Transactions.ExternalDbTransaction
     {
         public static void Run()
         {
-            var connectionString = @"Server=(localdb)\mssqllocaldb;Database=EFSaving.Transactions;Trusted_Connection=True;ConnectRetryCount=0";
+            var connectionString = @"Server=(localdb)\mssqllocaldb;Database=EFSaving.Transactions;Trusted_Connection=True";
 
             using (var context = new BloggingContext(
                 new DbContextOptionsBuilder<BloggingContext>()

--- a/samples/core/Saving/Saving/Transactions/SharingTransaction/Sample.cs
+++ b/samples/core/Saving/Saving/Transactions/SharingTransaction/Sample.cs
@@ -10,7 +10,7 @@ namespace EFSaving.Transactions.SharingTransaction
     {
         public static void Run()
         {
-            var connectionString = @"Server=(localdb)\mssqllocaldb;Database=EFSaving.Transactions;Trusted_Connection=True;ConnectRetryCount=0";
+            var connectionString = @"Server=(localdb)\mssqllocaldb;Database=EFSaving.Transactions;Trusted_Connection=True";
 
             using (var context = new BloggingContext(
                 new DbContextOptionsBuilder<BloggingContext>()


### PR DESCRIPTION
some of the connection strings seem to have `ConnectRetryCount=0`. i cant see why this would be the case for only a subset of connections, adn i cant see any doco in the md fiels that calls out why this should be the case. so assuming it is a copy paste issue, and submitting a PR that removes them.

if it is by design happy for this to be closed.