### PR TITLE
C113615: Adding break-line before snippet

### DIFF
--- a/entity-framework/core/modeling/query-types.md
+++ b/entity-framework/core/modeling/query-types.md
@@ -70,6 +70,7 @@ We use standard fluent configuration APIs to configure the mapping for the Query
 [!code-csharp[Main](../../../samples/core/QueryTypes/Program.cs#Configuration)]
 
 Next, we configure the `DbContext` to include the `DbQuery<T>`:
+
 [!code-csharp[Main](../../../samples/core/QueryTypes/Program.cs#DbQuery)]
 
 Finally, we can query the database view in the standard way:


### PR DESCRIPTION
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.
Description: Missing hard break-line before snippet is preventing content to show properly. 