### PR TITLE
C113612: Adding two spaces at the end of list items to avoid issues in live pages

### DIFF
--- a/entity-framework/ef6/fundamentals/async.md
+++ b/entity-framework/ef6/fundamentals/async.md
@@ -215,14 +215,14 @@ For a comprehensive list of available extension methods in the System.Data.Entit
 
 Now that the code is asynchronous, we can observe a different execution flow when we run the program:
 
-1.  **SaveChanges** begins to push the new **Blog** to the database
+1. **SaveChanges** begins to push the new **Blog** to the database  
     *Once the command is sent to the database no more compute time is needed on the current managed thread. The **PerformDatabaseOperations** method returns (even though it hasn't finished executing) and program flow in the Main method continues.*
-2.  **Quote of the day is written to Console**
+2. **Quote of the day is written to Console**  
     *Since there is no more work to do in the Main method, the managed thread is blocked on the Wait call until the database operation completes. Once it completes, the remainder of our **PerformDatabaseOperations** will be executed.*
-3.  **SaveChanges** completes
-4.  Query for all **Blogs** is sent to the database
+3.  **SaveChanges** completes  
+4.  Query for all **Blogs** is sent to the database  
     *Again, the managed thread is free to do other work while the query is processed in the database. Since all other execution has completed, the thread will just halt on the Wait call though.*
-5.  Query returns and results are written to **Console**
+5.  Query returns and results are written to **Console**  
 
 ![Async Output](~/ef6/media/asyncoutput.png) 
 


### PR DESCRIPTION
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.  
Description: missing spaces at the end of the reported strings created create content misalignment. Kindly consider adding 2 spaces as shown below.