### PR TITLE
fix typos

### DIFF
--- a/entity-framework/core/what-is-new/ef-core-3.0/features.md
+++ b/entity-framework/core/what-is-new/ef-core-3.0/features.md
@@ -58,7 +58,7 @@ await foreach(var o in orders)
 
 ### Nullable reference types 
 
-When this new feature is enabled in your code, EF Core can reason about the nullability of properties of refrence types (either of primitive types like string or navigation properties) to decide the nullability of columns and relationships in the database.
+When this new feature is enabled in your code, EF Core can reason about the nullability of properties of reference types (either of primitive types like string or navigation properties) to decide the nullability of columns and relationships in the database.
 
 ## Interception
 
@@ -94,7 +94,7 @@ public class OrderDetails
 ## EF 6.3 on .NET Core
 
 We understand that many existing applications use previous versions of EF, and that porting them to EF Core only to take advantage of .NET Core can sometimes require a significant effort.
-For that reason, we have enabled the newewst version of EF 6 to run on .NET Core 3.0.
+For that reason, we have enabled the newest version of EF 6 to run on .NET Core 3.0.
 There are some limitations, for example:
 - New providers are required to work on .NET Core
 - Spatial support with SQL Server won't be enabled

--- a/entity-framework/core/what-is-new/ef-core-3.0/features.md
+++ b/entity-framework/core/what-is-new/ef-core-3.0/features.md
@@ -101,7 +101,7 @@ There are some limitations, for example:
 
 ## Postponed features
 
-Some features originally planned for EF Core 3.0 were postponed to future releases: 
+Some features originally planned for EF Core 3.0 were postponed to future releases:
 
-- Ability to ingore parts of a model in migrations, tracked as [#2725](https://github.com/aspnet/EntityFrameworkCore/issues/2725).
+- Ability to ignore parts of a model in migrations, tracked as [#2725](https://github.com/aspnet/EntityFrameworkCore/issues/2725).
 - Property bag entities, tracked as two separate issues: [#9914](https://github.com/aspnet/EntityFrameworkCore/issues/9914) about shared-type entities and [#13610](https://github.com/aspnet/EntityFrameworkCore/issues/13610) about indexed property mapping support.


### PR DESCRIPTION
Add missing vowel to <q>ref<ins>e</ins>rence types</q>.
Remove extra consonant from <q>newe<del>w</del>st version</q>.
Rearrange <q>i<del>n</del>gore</q> as <q>ig<ins>n</ins>ore</q>.