### PR TITLE
Add breaking change for DbFunction.Schema empty string not a built-in…

### DIFF
--- a/entity-framework/core/what-is-new/ef-core-3.0/breaking-changes.md
+++ b/entity-framework/core/what-is-new/ef-core-3.0/breaking-changes.md
@@ -1732,15 +1732,15 @@ public static int? DatePart(string datePartArg, DateTime? date) => throw new Exc
 
 **New behavior**
 
-All DbFunction mappings are considered to be mapped to user defined functions. Hence empty string value would put the function inside default schema for the model. It can be default schema configured explicitly via fluent API `modelBuilder.HasDefaultSchema()` or `dbo`.
+All DbFunction mappings are considered to be mapped to user defined functions. Hence empty string value would put the function inside the default schema for the model. Which could be the schema configured explicitly via fluent API `modelBuilder.HasDefaultSchema()` or `dbo` otherwise.
 
 **Why**
 
-Earlier schema being empty was a way to treat that function is built-in but that logic is only applicable for SqlServer where built-in function does not belong to any schema.
+Previously schema being empty was a way to treat that function is built-in but that logic is only applicable for SqlServer where built-in functions do not belong to any schema.
 
 **Mitigations**
 
-Configure DbFunction's translation manually to map it to built-in function.
+Configure DbFunction's translation manually to map it to a built-in function.
 
 ```C#
 modelBuilder

--- a/entity-framework/core/what-is-new/ef-core-3.0/breaking-changes.md
+++ b/entity-framework/core/what-is-new/ef-core-3.0/breaking-changes.md
@@ -1722,7 +1722,7 @@ This change is introduced in EF Core 3.0-preview 7.
 
 **Old behavior**
 
-A DbFunction with value of schema being empty string configured the function to be in no schema and treated it as built-in function. For example following code will map `DatePart` CLR function to `DATEPART` built-in function on SqlServer.
+A DbFunction configured with schema as an empty string was treated as built-in function without a schema. For example following code will map `DatePart` CLR function to `DATEPART` built-in function on SqlServer.
 
 ```C#
 [DbFunction("DATEPART", Schema = "")]


### PR DESCRIPTION
… function anymore

Part of #1747