### PR TITLE
Update parameter name for clarity

### DIFF
--- a/samples/core/Modeling/FluentAPI/Relationships/OneToOne.cs
+++ b/samples/core/Modeling/FluentAPI/Relationships/OneToOne.cs
@@ -12,7 +12,7 @@ namespace EFModeling.FluentAPI.Relationships.OneToOne
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             modelBuilder.Entity<Blog>()
-                .HasOne(p => p.BlogImage)
+                .HasOne(b => b.BlogImage)
                 .WithOne(i => i.Blog)
                 .HasForeignKey<BlogImage>(b => b.BlogForeignKey);
         }


### PR DESCRIPTION
Updated the `HasOne` parameter name to be consistent with `HasForeignKey` so as not to cause confusion. Resolves https://github.com/aspnet/EntityFramework.Docs/issues/1626