### PR TITLE
Fix a typo in Cosmos DB Provider Docs

### DIFF
--- a/entity-framework/core/providers/cosmos/index.md
+++ b/entity-framework/core/providers/cosmos/index.md
@@ -46,7 +46,7 @@ Like for other providers the first step is to call [UseCosmos](/dotnet/api/Micro
 [!code-csharp[Configuration](../../../../samples/core/Cosmos/ModelBuilding/OrderContext.cs?name=Configuration)]
 
 > [!WARNING]
-> The endpoint and key are hardcoded here for simplicity, but in a production app these should be [stored securily](/aspnet/core/security/app-secrets#secret-manager)
+> The endpoint and key are hardcoded here for simplicity, but in a production app these should be [stored securely](/aspnet/core/security/app-secrets#secret-manager).
 
 In this example `Order` is a simple entity with a reference to the [owned type](../../modeling/owned-entities.md) `StreetAddress`.
 


### PR DESCRIPTION
Very small PR that fixes a typo on the Cosmos DB Provider docs.