### PR TITLE
Remove outdated information

### DIFF
--- a/entity-framework/core/get-started/install/index.md
+++ b/entity-framework/core/get-started/install/index.md
@@ -93,8 +93,6 @@ The `dotnet ef` commands are included in current versions of the .NET Core SDK, 
 dotnet add package Microsoft.EntityFrameworkCore.Design
 ```
 
-For ASP.NET Core apps, this package is included automatically.
-
 > [!IMPORTANT]
 > Always use the version of the tools package that matches the major version of the runtime packages.
 


### PR DESCRIPTION
ASP.NET Core 3.0 does not automatically reference `Microsoft.EntityFrameworkCore.Design`. I did not mention that this is not necessary on ASP.NET Core 2.2 and earlier as this may confuse customers, and they'll need to add this reference once they upgrade anyways.