### PR TITLE
Recommend Docs Authoring Pack extension and configure dev langs

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+	"recommendations": [
+		"docsmsft.docs-authoring-pack"
+	]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,12 @@
+{
+    "markdown.docsetLanguages": [
+        ".NET Core CLI",
+        "C#",
+        "JSON",
+        "PowerShell",
+        "SQL",
+        "VB.NET",
+        "XAML",
+        "XML"
+    ]
+}


### PR DESCRIPTION
Recommend the [Docs Authoring Pack](https://marketplace.visualstudio.com/items?itemName=docsmsft.docs-authoring-pack) extension to contributors using VS Code (if it's not already installed). Additionally, configure the most commonly used dev langs in this docset. This helps contributors select the appropriate code fence dev lang when typing 3 backticks. See https://github.com/aspnet/AspNetCore.Docs/pull/16986 for a preview of the functionality.

/cc: @ajcvickers for awareness