### PR TITLE
fix: minor typo forgot -> forget in ef core what's new page

### DIFF
--- a/entity-framework/core/what-is-new/ef-core-8.0/whatsnew.md
+++ b/entity-framework/core/what-is-new/ef-core-8.0/whatsnew.md
@@ -2236,7 +2236,7 @@ Finally, we worked with Eric Sink in the [SQLitePCLRaw project](https://github.c
 
 ## Checking for pending model changes
 
-We've added a new `dotnet ef` command to check whether any model changes have been made since the last migration. This can be useful in CI/CD scenarios to ensure you or a teammate didn't forgot to add a migration.
+We've added a new `dotnet ef` command to check whether any model changes have been made since the last migration. This can be useful in CI/CD scenarios to ensure you or a teammate didn't forget to add a migration.
 
 ```dotnetcli
 dotnet ef migrations has-pending-model-changes


### PR DESCRIPTION
The `What's New` page for ef core 8 has a minor typo "a teammate didn't forgot to add a migration". This changes "forgot" to "forget"