### PR TITLE
Explain "payload".

### DIFF
--- a/entity-framework/core/modeling/relationships/many-to-many.md
+++ b/entity-framework/core/modeling/relationships/many-to-many.md
@@ -266,7 +266,7 @@ CREATE TABLE "PostTag" (
 
 ## Many-to-many with class for join entity
 
-So far in the examples, the join table has been automatically mapped to a [shared-type entity type](xref:core/modeling/entity-types#shared-type-entity-types). This removes the need for a dedicated class to be created for the entity type. However, it can be useful to have such a class so that it can be referenced easily, especially when navigations or a payload are added to the class, as is shown in later examples below (A "payload" is any additional data in the join table, for example, the timestamp in which an entry in the join table is created). To do this, first create a type `PostTag` for the join entity in addition to the existing types for `Post` and `Tag`:
+So far in the examples, the join table has been automatically mapped to a [shared-type entity type](xref:core/modeling/entity-types#shared-type-entity-types). This removes the need for a dedicated class to be created for the entity type. However, it can be useful to have such a class so that it can be referenced easily, especially when navigations or a payload (A "payload" is any additional data in the join table. For example, the timestamp in which an entry in the join table is created.) are added to the class, as is shown in later examples below. To do this, first create a type `PostTag` for the join entity in addition to the existing types for `Post` and `Tag`:
 
 <!--
         public class Post


### PR DESCRIPTION
The word payload is introduced without a corresponding definition, leaving the reader a bit confused. This provides a succinct definition when first encountering the term  in the article.