### PR TITLE
Fix typo in "What's New in EF Core 10"

### DIFF
--- a/entity-framework/core/what-is-new/ef-core-10.0/whatsnew.md
+++ b/entity-framework/core/what-is-new/ef-core-10.0/whatsnew.md
@@ -321,7 +321,7 @@ public struct Address
 }
 ```
 
-This aligns well with complex types not having an identity of their own, and only being found within entity types which have an identity. However, collections of structs currently aren't currently supported.
+This aligns well with complex types not having an identity of their own, and only being found within entity types which have an identity. However, collections of structs aren't currently supported.
 
 ### Complex and owned entity types
 


### PR DESCRIPTION
`However, collections of structs currently aren't currently supported.` was changed to `However, collections of structs aren't currently supported.`