### PR TITLE
Fix wording for clarity in best practices section

### DIFF
--- a/entity-framework/core/index.md
+++ b/entity-framework/core/index.md
@@ -47,7 +47,7 @@ While EF Core is good at abstracting many programming details, there are some be
 
 * Intermediate-level knowledge or higher of the underlying database server is essential to architect, debug, profile, and migrate data in high performance production apps. For example, knowledge of primary and foreign keys, constraints, indexes, normalization, DML and DDL statements, data types, profiling, etc.
 * Functional and integration testing:  It's important to replicate the production environment as closely as possible to:
-  * Find issues in the app that only show up when using a specific versions or edition of the database server.
+  * Find issues in the app that only show up when using a specific version or edition of the database server.
   * Catch breaking changes when upgrading EF Core and other dependencies. For example, adding or upgrading frameworks like ASP.NET Core, OData, or AutoMapper. These dependencies can affect EF Core in unexpected ways.
 * Performance and stress testing with representative loads. The naïve usage of some features doesn't scale well. For example, multiple collections Includes, heavy use of lazy loading, conditional queries on non-indexed columns, massive updates and inserts with store-generated values, lack of concurrency handling, large models, inadequate cache policy.
 * Security review: For example, handling of connection strings and other secrets, database permissions for non-deployment operation, input validation for raw SQL, encryption for sensitive data. See [Secure authentication flows](/aspnet/core/security/#secure-authentication-flows) for secure configuration and authentication flow.


### PR DESCRIPTION
Corrected the wording from 'specific versions' to 'specific version' for clarity.