### PR TITLE
Consistency fixes in EF Core Database Provider docs

### DIFF
--- a/entity-framework/core/providers/sql-server/index.md
+++ b/entity-framework/core/providers/sql-server/index.md
@@ -68,7 +68,7 @@ When using EF with dependency injection (e.g. ASP.NET), use the following:
 ```c#
 var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddDbContext<MyContext>(options =>
-    options.UseSqlServer(builder.Configuration.GetConnectionString("MyContext")));
+    options.UseAzureSql(builder.Configuration.GetConnectionString("MyContext")));
 ```
 
 > [!NOTE]
@@ -91,7 +91,7 @@ When using EF with dependency injection (e.g. ASP.NET), use the following:
 ```c#
 var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddDbContext<MyContext>(options =>
-    options.UseSqlServer(builder.Configuration.GetConnectionString("MyContext")));
+    options.UseAzureSynapse(builder.Configuration.GetConnectionString("MyContext")));
 ```
 
 > [!NOTE]


### PR DESCRIPTION
The same configuration approach should be followed in DI and non-DI scenarios. Therefore, for consistency, I propose using `UseAzureSql` in the Azure SQL tab and `UseAzureSynapse` for Azure Synapse Analytics respectively.