### PR TITLE
Fix dotnet counters monitor invocation

### DIFF
--- a/entity-framework/core/logging-events-diagnostics/metrics.md
+++ b/entity-framework/core/logging-events-diagnostics/metrics.md
@@ -118,7 +118,7 @@ Inside your .NET application, the process ID is available as `Process.GetCurrent
 Finally, launch `dotnet-counters` as follows:
 
 ```console
-dotnet counters monitor Microsoft.EntityFrameworkCore -p <PID>
+dotnet counters monitor --counters Microsoft.EntityFrameworkCore -p <PID>
 ```
 
 `dotnet-counters` will now attach to your running process and start reporting continuous counter data:


### PR DESCRIPTION
The `--counters` option must be specified in order to only monitor a specific provider like Microsoft.EntityFrameworkCore.

More info: https://learn.microsoft.com/en-us/dotnet/core/diagnostics/dotnet-counters#dotnet-counters-monitor

Otherwise it outputs the following message:
> --counters is unspecified. Monitoring System.Runtime counters by default.