### PR TITLE
Update LocalDb extension description

### DIFF
--- a/entity-framework/core/extensions/index.md
+++ b/entity-framework/core/extensions/index.md
@@ -104,7 +104,7 @@ Extends [Verify](https://github.com/VerifyTests/Verify) to allow snapshot testin
 
 ### LocalDb
 
-Provides a wrapper around [SQL Server Express LocalDB](/sql/database-engine/configure-windows/sql-server-express-localdb) to simplify running tests against Entity Framework. For EF Core: 3-8.
+Provides a wrapper around [SQL Server Express LocalDB](/sql/database-engine/configure-windows/sql-server-express-localdb) to simplify running tests against Entity Framework.
 
 [GitHub repository](https://github.com/SimonCropp/LocalDb) | [NuGet](https://www.nuget.org/packages/EfLocalDb)
 


### PR DESCRIPTION
Removed EF Core version range from the LocalDb extension description to generalize its applicability.