### PR TITLE
Change BillingAddress to allow NULL values

### DIFF
--- a/entity-framework/core/what-is-new/ef-core-10.0/whatsnew.md
+++ b/entity-framework/core/what-is-new/ef-core-10.0/whatsnew.md
@@ -304,7 +304,7 @@ CREATE TABLE [Customers] (
     [Id] int NOT NULL IDENTITY,
     [Name] nvarchar(max) NOT NULL,
     [ShippingAddress] json NOT NULL,
-    [BillingAddress] json NULL,
+    [BillingAddress] json NOT NULL,
     CONSTRAINT [PK_Customers] PRIMARY KEY ([Id])
 );
 ```


### PR DESCRIPTION
"NOT NULL NULL" is not valid T-SQL. Given it refers to the previous type, allowing this column to be nullable seems to be what was intended.