### PR TITLE
Update recommendation for separate migrations projects

### DIFF
--- a/entity-framework/core/managing-schemas/migrations/projects.md
+++ b/entity-framework/core/managing-schemas/migrations/projects.md
@@ -8,7 +8,7 @@ uid: core/managing-schemas/migrations/projects
 
 # Using a Separate Migrations Project
 
-You may want to store your migrations in a different project than the one containing your `DbContext`. This is recommended if your project uses a platform-specific project type that the EF tools don't support, such as WinUI, Xamarin, MAUI, Blazor, or Azure Functions, or if it targets a specific runtime identifier (RID). You can also use this strategy to maintain multiple sets of migrations, for example, one for development and another for release-to-release upgrades.
+You may want to store your migrations in a different project than the one containing your `DbContext`. This is recommended if your project uses a platform-specific project type, such as WinUI, Xamarin, MAUI, Blazor, or Azure Functions, or if it targets a specific runtime identifier (RID). You can also use this strategy to maintain multiple sets of migrations, for example, one for development and another for release-to-release upgrades.
 
 > [!TIP]
 > You can view this article's [sample on GitHub](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Schemas/ThreeProjectMigrations).


### PR DESCRIPTION
Clarify recommendation for using separate migrations projects for platform-specific cases.