### PR TITLE
Update docs for EF Core 11 full-text/vector API renames

### DIFF
--- a/entity-framework/core/providers/sql-server/full-text-search.md
+++ b/entity-framework/core/providers/sql-server/full-text-search.md
@@ -31,23 +31,23 @@ protected override void OnModelCreating(ModelBuilder modelBuilder)
 
     modelBuilder.Entity<Article>()
         .HasFullTextIndex(a => a.Contents)
-        .HasKeyIndex("PK_Articles")
-        .OnCatalog("ftCatalog");
+        .UseKeyIndex("PK_Articles")
+        .UseCatalog("ftCatalog");
 }
 ```
 
-The `HasKeyIndex()` method specifies the unique, non-nullable, single-column index used as the full-text key for the table (typically the primary key index). `OnCatalog()` assigns the full-text index to a specific catalog.
+The `UseKeyIndex()` method specifies the unique, non-nullable, single-column index used as the full-text key for the table (typically the primary key index). `UseCatalog()` assigns the full-text index to a specific catalog.
 
 You can also configure multiple columns and additional options such as per-column languages and change tracking:
 
 ```csharp
 modelBuilder.Entity<Article>()
     .HasFullTextIndex(a => new { a.Title, a.Contents })
-    .HasKeyIndex("PK_Articles")
-    .OnCatalog("ftCatalog")
-    .WithChangeTracking(FullTextChangeTracking.Manual)
-    .HasLanguage("Title", "English")
-    .HasLanguage("Contents", "French");
+    .UseKeyIndex("PK_Articles")
+    .UseCatalog("ftCatalog")
+    .HasChangeTracking(FullTextChangeTracking.Manual)
+    .UseLanguage("Title", "English")
+    .UseLanguage("Contents", "French");
 ```
 
 The full-text catalog can also be configured as the default catalog, and with accent sensitivity:
@@ -185,7 +185,7 @@ The above automatically searches across all columns registered for full-text sea
 ```csharp
 var results = await context.Articles
     .Join(
-        context.Articles.FreeTextTable<Article, int>(a => a.Contents, "veggies"),
+        context.Articles.FreeTextTable<Article, int>("veggies", a => a.Contents),
         a => a.Id,
         ftt => ftt.Key,
         (a, ftt) => new { Article = a, ftt.Rank })
@@ -197,7 +197,7 @@ var results = await context.Articles
 
 ```csharp
 var results = await context.Articles
-    .FreeTextTable(a => new { a.Title, a.Contents }, "veggies")
+    .FreeTextTable("veggies", a => new { a.Title, a.Contents })
     .Select(r => new { Article = r.Value, Rank = r.Rank })
     .OrderByDescending(r => r.Rank)
     .ToListAsync();
@@ -224,7 +224,7 @@ Both table-valued functions support a `topN` parameter to limit the number of re
 
 ```csharp
 var results = await context.Articles
-    .FreeTextTable(a => a.Contents, "veggies", topN: 10)
+    .FreeTextTable("veggies", a => a.Contents, topN: 10)
     .Select(r => new { Article = r.Value, Rank = r.Rank })
     .OrderByDescending(r => r.Rank)
     .ToListAsync();
@@ -236,7 +236,7 @@ Both table-valued functions support specifying a language term for linguistic ma
 
 ```csharp
 var results = await context.Articles
-    .FreeTextTable(a => a.Contents, "veggies", languageTerm: "English")
+    .FreeTextTable("veggies", a => a.Contents, languageTerm: "English")
     .Select(r => new { Article = r.Value, Rank = r.Rank })
     .ToListAsync();
 ```

--- a/entity-framework/core/what-is-new/ef-core-11.0/whatsnew.md
+++ b/entity-framework/core/what-is-new/ef-core-11.0/whatsnew.md
@@ -273,8 +273,8 @@ modelBuilder.HasFullTextCatalog("ftCatalog");
 
 modelBuilder.Entity<Blog>()
     .HasFullTextIndex(b => b.FullName)
-    .HasKeyIndex("PK_Blogs")
-    .OnCatalog("ftCatalog");
+    .UseKeyIndex("PK_Blogs")
+    .UseCatalog("ftCatalog");
 ```
 
 This generates the following SQL in a migration:
@@ -297,14 +297,14 @@ However, SQL Server also has table-valued function versions of these functions, 
 ```csharp
 // Using FreeTextTable with a search query
 var results = await context.Blogs
-    .FreeTextTable(b => b.FullName, "John")
+    .FreeTextTable("John", b => b.FullName)
     .Select(r => new { Blog = r.Value, Rank = r.Rank })
     .OrderByDescending(r => r.Rank)
     .ToListAsync();
 
 // Using ContainsTable with a search query
 var results = await context.Blogs
-    .ContainsTable(b => b.FullName, "John")
+    .ContainsTable("John", b => b.FullName)
     .Select(r => new { Blog = r.Value, Rank = r.Rank })
     .OrderByDescending(r => r.Rank)
     .ToListAsync();


### PR DESCRIPTION
Updates documentation to reflect API changes from dotnet/efcore#38027 (dotnet/efcore#37993):

### Full-text index builder renames
- `HasKeyIndex()` → `UseKeyIndex()`
- `OnCatalog()` → `UseCatalog()`
- `WithChangeTracking()` → `HasChangeTracking()`
- `HasLanguage()` → `UseLanguage()`

### FreeTextTable/ContainsTable parameter reordering
- `columnSelector` moved after search text and made optional
- e.g. `.FreeTextTable(a => a.Title, "query")` → `.FreeTextTable("query", a => a.Title)`

### Files updated
- `entity-framework/core/providers/sql-server/full-text-search.md`
- `entity-framework/core/what-is-new/ef-core-11.0/whatsnew.md`