### PR TITLE
Fix SQL stored procedure syntax by using SELECT instead of RETURN

### DIFF
--- a/entity-framework/core/managing-schemas/migrations/managing.md
+++ b/entity-framework/core/managing-schemas/migrations/managing.md
@@ -151,7 +151,7 @@ migrationBuilder.Sql(
         @LastName nvarchar(50),
         @FirstName nvarchar(50)
     AS
-        RETURN @LastName + @FirstName;')");
+        SELECT @LastName + @FirstName;')");
 ```
 
 > [!TIP]


### PR DESCRIPTION
In SQL Server, RETURN is intended only for integer status codes so that SELECT is the correct for returning computed string results from a stored procedure