### PR TITLE
Add what's new note for ToAsyncEnumerable analyzer (#37670)

### DIFF
--- a/entity-framework/core/what-is-new/ef-core-11.0/whatsnew.md
+++ b/entity-framework/core/what-is-new/ef-core-11.0/whatsnew.md
@@ -710,3 +710,4 @@ For more information, see [Configuration file](xref:core/cli/dotnet#configuratio
 ## Other improvements
 
 * The EF command-line tool now writes all logging and status messages to standard error, reserving standard output only for the command's actual expected output. For example, when generating a migration SQL script with `dotnet ef migrations script`, only the SQL is written to standard output.
+* An analyzer and code fix now warn when `ToAsyncEnumerable` is used instead of `AsAsyncEnumerable` on EF queries ([#37670](https://github.com/dotnet/efcore/issues/37670), many thanks to [@m-x-shokhzod](https://github.com/m-x-shokhzod)).


### PR DESCRIPTION
Adds a one-line entry to the EF Core 11 "What's New" doc noting the new analyzer and code fix that warns when `ToAsyncEnumerable` is used instead of `AsAsyncEnumerable` on EF queries, with thanks to the community contributor.