### PR TITLE
docs: Document that ApplyConfigurationsFromAssembly requires a parameterless constructor

### DIFF
--- a/entity-framework/core/modeling/index.md
+++ b/entity-framework/core/modeling/index.md
@@ -42,6 +42,9 @@ It is possible to apply all configuration specified in types implementing `IEnti
 > [!NOTE]
 > The order in which the configurations will be applied is undefined, therefore this method should only be used when the order doesn't matter.
 
+> [!NOTE]
+> `ApplyConfigurationsFromAssembly` only instantiates configuration types that have a parameterless constructor; the constructor may be public or non-public. Types whose constructors require parameters are skipped, and a `SkippedEntityTypeConfigurationWarning` is logged. To apply such configurations, instantiate them manually and pass them to <xref:Microsoft.EntityFrameworkCore.ModelBuilder.ApplyConfiguration%2A>.
+
 #### Using `EntityTypeConfigurationAttribute` on entity types
 
 Rather than explicitly calling `Configure`, an <xref:Microsoft.EntityFrameworkCore.EntityTypeConfigurationAttribute> can instead be placed on the entity type such that EF Core can find and use appropriate configuration. For example:


### PR DESCRIPTION
## Summary

Fixes #3207.

`ApplyConfigurationsFromAssembly` only instantiates configuration types that have a parameterless constructor, but this isn't currently documented. Users hit surprising behavior when their `IEntityTypeConfiguration<T>` implementations have non-default constructors (e.g. for DI).

This PR adds a `[!NOTE]` block to `entity-framework/core/modeling/index.md` next to the existing "order is undefined" note, describing:

- A parameterless constructor is required — may be public or non-public (implementation: `BindingFlags.Public | BindingFlags.NonPublic` + `Activator.CreateInstance(type, nonPublic: true)` in [ModelBuilder.cs](https://github.com/dotnet/efcore/blob/main/src/EFCore/ModelBuilder.cs)).
- Types lacking such a constructor are skipped, with a `SkippedEntityTypeConfigurationWarning` logged.
- To apply a configuration whose constructor requires arguments, instantiate it manually and pass it to `ApplyConfiguration`.

Mirrors the style of the adjacent NOTE.
