### PR TITLE
docs: clarify PMC PowerShell command wording

### DIFF
--- a/entity-framework/core/cli/powershell.md
+++ b/entity-framework/core/cli/powershell.md
@@ -16,13 +16,13 @@ If you aren't using Visual Studio, we recommend the [EF Core Command-line Tools]
 
 ## Install the tools
 
-Install the Package Manager Console tools by running the following command in **Package Manager Console**:
+Install the Package Manager Console tools by running the following PowerShell command in **Package Manager Console**:
 
 ```powershell
 Install-Package Microsoft.EntityFrameworkCore.Tools
 ```
 
-Update the tools by running the following command in **Package Manager Console**.
+Update the tools by running the following PowerShell command in **Package Manager Console**.
 
 ```powershell
 Update-Package Microsoft.EntityFrameworkCore.Tools


### PR DESCRIPTION
## Summary

Fixes #4974

## Changes
- clarify that the install and update snippets are PowerShell commands run inside Package Manager Console
- keep the existing snippets unchanged while removing the labeling mismatch noted in the issue

## Testing
- ran git diff --check
- reviewed the rendered markdown change in entity-framework/core/cli/powershell.md