### PR TITLE
docs: fix UsingEntity lambda order in scaffolding sample

### DIFF
--- a/entity-framework/core/managing-schemas/scaffolding/index.md
+++ b/entity-framework/core/managing-schemas/scaffolding/index.md
@@ -417,8 +417,8 @@ entity.HasMany(d => d.Tags)
     .WithMany(p => p.Posts)
     .UsingEntity<Dictionary<string, object>>(
         "PostTag",
-        l => l.HasOne<Tag>().WithMany().HasForeignKey("PostsId"),
-        r => r.HasOne<Post>().WithMany().HasForeignKey("TagsId"),
+        r => r.HasOne<Tag>().WithMany().HasForeignKey("TagsId"),
+        l => l.HasOne<Post>().WithMany().HasForeignKey("PostsId"),
         j =>
             {
                 j.HasKey("PostsId", "TagsId");

--- a/samples/core/Miscellaneous/NewInEFCore6/ScaffoldingSample.cs
+++ b/samples/core/Miscellaneous/NewInEFCore6/ScaffoldingSample.cs
@@ -116,8 +116,8 @@ public static class ScaffoldingSample
                             .WithMany(p => p.Posts)
                             .UsingEntity<Dictionary<string, object>>(
                                 "PostTag",
-                                l => l.HasOne<Tag>().WithMany().HasForeignKey("PostsId"),
-                                r => r.HasOne<Post>().WithMany().HasForeignKey("TagsId"),
+                                r => r.HasOne<Tag>().WithMany().HasForeignKey("TagsId"),
+                                l => l.HasOne<Post>().WithMany().HasForeignKey("PostsId"),
                                 j =>
                                     {
                                         j.HasKey("PostsId", "TagsId");


### PR DESCRIPTION
## Summary

Fixes #5014

## Changes
- swap the `UsingEntity` lambda order in the scaffolding docs snippet
- align the foreign keys with the `configureRight`/`configureLeft` ordering used by the API and existing relationship samples

## Testing
- ran git diff --check
- verified the corrected snippet matches the established many-to-many sample ordering in `samples/core/Modeling/Relationships/ManyToMany.cs`