### PR TITLE
docs: mention no-pluralize in scaffolding guide

### DIFF
--- a/entity-framework/core/managing-schemas/scaffolding/index.md
+++ b/entity-framework/core/managing-schemas/scaffolding/index.md
@@ -136,6 +136,8 @@ Scaffold-DbContext ... -Tables Customer.Purchases, Contractor.Accounts, Contract
 
 Table and column names are fixed up to better match the .NET naming conventions for types and properties by default. Specifying `-UseDatabaseNames` (Visual Studio PMC) or `--use-database-names` (.NET CLI) will disable this behavior preserving the original database names as much as possible. Invalid .NET identifiers will still be fixed and synthesized names like navigation properties will still conform to .NET naming conventions.
 
+To disable the pluralizer when scaffolding reverse-engineered models, use `-NoPluralize` (Visual Studio PMC) or `--no-pluralize` (.NET CLI).
+
 For example, consider the following tables:
 
 ```sql


### PR DESCRIPTION
## Summary

Fixes #5112

## Changes
- document the `-NoPluralize` / `--no-pluralize` option on the reverse-engineering guide
- place the note next to the existing naming guidance so scaffolded naming options are discoverable in one place

## Testing
- ran git diff --check
- verified the option wording matches the CLI reference and EF Core 5 breaking-change documentation