### PR TITLE
Add note about PendingModelChangesWarning behavior in EF Core 9

### DIFF
--- a/entity-framework/core/managing-schemas/migrations/applying.md
+++ b/entity-framework/core/managing-schemas/migrations/applying.md
@@ -355,6 +355,16 @@ Migration locking applies when migrations are applied using any of the following
 
 [SQL scripts](#sql-scripts) are not affected by migration locking, since they are applied outside of EF Core.
 
+> [!NOTE]
+> Starting with EF Core 9, calling `Migrate()` or `MigrateAsync()` will 
+> throw a `PendingModelChangesWarning` exception when the model has 
+> pending changes compared to the last migration. To detect this 
+> condition before deployment, use the 
+> [`dotnet ef migrations has-pending-model-changes`](managing.md#checking-for-pending-model-changes) 
+> command in your CI/CD pipeline. The warning can be suppressed via 
+> `ConfigureWarnings` if necessary, but this is generally not 
+> recommended in production scenarios.
+
 > [!WARNING]
 > The locking mechanism varies significantly across database providers and can involve provider-specific issues. For example, the SQLite provider uses a lock table that can become [abandoned if the process terminates unexpectedly](xref:core/providers/sqlite/limitations#concurrent-migrations-protection). Always consult your provider's documentation for details.
 

--- a/entity-framework/core/managing-schemas/migrations/applying.md
+++ b/entity-framework/core/managing-schemas/migrations/applying.md
@@ -356,14 +356,7 @@ Migration locking applies when migrations are applied using any of the following
 [SQL scripts](#sql-scripts) are not affected by migration locking, since they are applied outside of EF Core.
 
 > [!NOTE]
-> Starting with EF Core 9, calling `Migrate()` or `MigrateAsync()` will 
-> throw a `PendingModelChangesWarning` exception when the model has 
-> pending changes compared to the last migration. To detect this 
-> condition before deployment, use the 
-> [`dotnet ef migrations has-pending-model-changes`](managing.md#checking-for-pending-model-changes) 
-> command in your CI/CD pipeline. The warning can be suppressed via 
-> `ConfigureWarnings` if necessary, but this is generally not 
-> recommended in production scenarios.
+> Starting with EF Core 9, calling `Migrate()` or `MigrateAsync()` will throw an exception when the model has pending changes compared to the last migration (warning event ID `RelationalEventId.PendingModelChangesWarning`). To detect this condition before deployment, use the [`dotnet ef migrations has-pending-model-changes`](xref:core/managing-schemas/migrations/managing#checking-for-pending-model-changes) command in your CI/CD pipeline. The warning can be suppressed via `ConfigureWarnings` (ignoring `RelationalEventId.PendingModelChangesWarning`) if necessary, but this is generally not recommended in production scenarios. See the [breaking change note](xref:core/what-is-new/ef-core-9.0/breaking-changes#pending-model-changes) for more information.
 
 > [!WARNING]
 > The locking mechanism varies significantly across database providers and can involve provider-specific issues. For example, the SQLite provider uses a lock table that can become [abandoned if the process terminates unexpectedly](xref:core/providers/sqlite/limitations#concurrent-migrations-protection). Always consult your provider's documentation for details.


### PR DESCRIPTION
## Summary

EF Core 9 introduced a behavioral change where `Migrate()` and `MigrateAsync()` throw a `PendingModelChangesWarning` exception when the model has pending changes compared to the last migration. This is documented in the [EF Core 9 breaking changes page](https://learn.microsoft.com/en-us/ef/core/what-is-new/ef-core-9.0/breaking-changes) but is not surfaced in the primary documentation about applying migrations.

## Changes

- Added a note in the "Migration locking" section of `applying.md`, immediately after the existing `SQL scripts are not affected by migration locking` paragraph
- Cross-linked to the existing `has-pending-model-changes` command in `managing.md` as the recommended detection pattern
- Note placement follows existing `[!NOTE]` / `[!WARNING]` conventions used elsewhere in the file

## Why this matters

Developers encountering the `PendingModelChangesWarning` exception during `Migrate()` calls in production deployments typically search the runtime migration documentation first. Without a cross-reference, they may not discover the existing detection command that prevents this issue in CI/CD pipelines.

## Verification

- Cross-link target `managing.md#checking-for-pending-model-changes` exists in the destination file
- Note format matches existing `[!NOTE]` blocks in the documentation
- Preview confirmed correct rendering