### PR TITLE
Add note about EF Core 9 PendingModelChangesWarning behavior

### DIFF
--- a/entity-framework/core/managing-schemas/migrations/managing.md
+++ b/entity-framework/core/managing-schemas/migrations/managing.md
@@ -221,6 +221,9 @@ dotnet ef migrations has-pending-model-changes
 
 You can also perform this check programmatically using `context.Database.HasPendingModelChanges()`. This can be used to write a unit test that fails when you forget to add a migration.
 
+> [!NOTE]
+> Starting with EF Core 9, an exception is thrown automatically when `Migrate()` or `MigrateAsync()` is called with pending model changes (warning event ID `RelationalEventId.PendingModelChangesWarning`). See the [applying migrations documentation](xref:core/managing-schemas/migrations/applying#apply-migrations-at-runtime) and the [breaking change note](xref:core/what-is-new/ef-core-9.0/breaking-changes#pending-model-changes) for more information.
+
 ## Resetting all migrations
 
 In some extreme cases, it may be necessary to remove all migrations and start over. This can be easily done by deleting your **Migrations** folder and dropping your database; at that point you can create a new initial migration, which will contain your entire current schema.

--- a/entity-framework/core/managing-schemas/migrations/managing.md
+++ b/entity-framework/core/managing-schemas/migrations/managing.md
@@ -222,7 +222,7 @@ dotnet ef migrations has-pending-model-changes
 You can also perform this check programmatically using `context.Database.HasPendingModelChanges()`. This can be used to write a unit test that fails when you forget to add a migration.
 
 > [!NOTE]
-> Starting with EF Core 9, an exception is thrown automatically when `Migrate()` or `MigrateAsync()` is called with pending model changes (warning event ID `RelationalEventId.PendingModelChangesWarning`). See the [applying migrations documentation](xref:core/managing-schemas/migrations/applying#apply-migrations-at-runtime) and the [breaking change note](xref:core/what-is-new/ef-core-9.0/breaking-changes#pending-model-changes) for more information.
+> Starting with EF Core 9, calling <xref:Microsoft.EntityFrameworkCore.RelationalDatabaseFacadeExtensions.Migrate*> or <xref:Microsoft.EntityFrameworkCore.RelationalDatabaseFacadeExtensions.MigrateAsync*> with pending model changes throws an exception (event ID <xref:Microsoft.EntityFrameworkCore.Diagnostics.RelationalEventId.PendingModelChangesWarning>). See the [applying migrations documentation](xref:core/managing-schemas/migrations/applying#apply-migrations-at-runtime) and the [breaking change note](xref:core/what-is-new/ef-core-9.0/breaking-changes#pending-model-changes) for more information.
 
 ## Resetting all migrations
 


### PR DESCRIPTION
## Summary

Complements PR #5390 by adding the inverse cross-reference: while #5390 added a note in `applying.md` about the EF Core 9 `PendingModelChangesWarning` exception behavior, the `managing.md` page (which documents the `has-pending-model-changes` command) doesn't mention that this check is now performed automatically at runtime in EF Core 9.

## Changes

- Added a note in the "Checking for pending model changes" section of `managing.md`, after the existing programmatic check description
- Cross-linked to both `applying.md#apply-migrations-at-runtime` and the EF Core 9 breaking change page
- Note format and xref syntax match PR #5390 conventions

## Why this matters

A developer reading `managing.md` learns about `has-pending-model-changes` as a check command but doesn't discover that EF Core 9 now performs this check automatically when `Migrate()` is called. The inverse direction (applying.md → managing.md) was addressed in #5390; this PR completes the bidirectional cross-reference.

## Related

- #5390 (already merged) — added the reverse direction note in `applying.md`