### PR TITLE
Document the model used by the eager loading examples

### DIFF
--- a/entity-framework/core/querying/related-data/eager.md
+++ b/entity-framework/core/querying/related-data/eager.md
@@ -7,6 +7,17 @@ uid: core/querying/related-data/eager
 ---
 # Eager Loading of Related Data
 
+## The model
+
+The examples in this article use a blogging model with a `Blog` that has many `Post`s. Each `Blog` also has an owner and a `Theme`, and each `Post` has an author and a set of tags:
+
+[!code-csharp[Main](../../../../samples/core/Querying/RelatedData/Blog.cs)]
+
+[!code-csharp[Main](../../../../samples/core/Querying/RelatedData/Post.cs)]
+
+> [!TIP]
+> You can view the [sample](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Querying/RelatedData) for this article on GitHub.
+
 ## Eager loading
 
 You can use the `Include` method to specify related data to be included in query results. In the following example, the blogs that are returned in the results will have their `Posts` property populated with the related posts.


### PR DESCRIPTION
Fixes #3105.

The eager loading examples query `Blog` and `Post`, but the article never shows what those types look like. This adds a short "The model" section at the top that references the `Blog.cs` and `Post.cs` sample files (per the contributing guidelines), plus a tip linking to the full sample.

Docs-only change; markdownlint passes.